### PR TITLE
Disable deep copy of nested object, allowing to change properties of instances inside classes after their instantiation

### DIFF
--- a/iiif_prezi3/base.py
+++ b/iiif_prezi3/base.py
@@ -5,6 +5,7 @@ class Base(BaseModel):
 
     class Config:
         validate_assignment = True
+        copy_on_model_validation = False
 
     def __getattribute__(self, prop):
         val = super(Base, self).__getattribute__(prop)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -11,6 +11,24 @@ sys.path.insert(1, '.')
 
 class BasicTest(unittest.TestCase):
 
+    def test_copy_on_model_validation(self):
+        """Test if the copy_on_model_validation is working.
+
+        Test if the user can change the values of the IIIF object after it has
+        been instantiated using the reference to the original object.
+        """
+        originalID = 'http://iiif.example.org/TESTORIGINAL'
+        amanifest = Manifest(id='http://iiif.example.org/prezi/Manifest/0', type='Manifest', label={'en': ['default label']})
+        acanvas = Canvas(id='http://iiif.example.org/prezi/Manifest/0/canvas/01', type='Canvas', label={'en': ['default label']})
+        asecondcanvas = Canvas(id=originalID, type='Canvas', label={'en': ['second label']})
+        changedID = 'http://iiif.example.org/TESTCHANGED'
+        amanifest.items = [acanvas, asecondcanvas]
+        # we change the id of the first canvas
+        acanvas.id = changedID
+        self.assertEqual(amanifest.items[0].id, changedID)
+        # we check that the second canvas has not been changed
+        self.assertEqual(amanifest.items[1].id, originalID)
+
     def testLoadManifest(self):
         """Tests JSON file opening, extension is picked up, and the fields are correct."""
         with open('tests/fixtures/0003-mvm-video.json') as json_file:


### PR DESCRIPTION
The user can now change the values of the IIIF object after it has been instantiated using the reference to the original object.


```python
from iiif_prezi3 import Canvas, Manifest

originalID = 'http://iiif.example.org/TESTORIGINAL'
amanifest = Manifest(id='http://iiif.example.org/prezi/Manifest/0', type='Manifest', label={'en': ['default label']})
acanvas = Canvas(id='http://iiif.example.org/prezi/Manifest/0/canvas/01', type='Canvas', label={'en': ['default label']})
asecondcanvas = Canvas(id=originalID, type='Canvas', label={'en': ['second label']})
changedID = 'http://iiif.example.org/TESTCHANGED'
amanifest.items = [acanvas, asecondcanvas]
# we change the id of the first canvas
acanvas.id = changedID
amanifest.items[0].id, changedID

```
This should fix: https://github.com/iiif-prezi/iiif-prezi3/issues/35