### PR TITLE
add jsonld function to base model

### DIFF
--- a/iiif_prezi3/base.py
+++ b/iiif_prezi3/base.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-
+import json
 
 class Base(BaseModel):
 
@@ -24,3 +24,18 @@ class Base(BaseModel):
         else:
             self.__class__._defaulters = []
         super().__init__(**kw)
+
+    def json(self, **kwargs):
+        return self.jsonld(**kwargs)
+    
+    def jsonld(self, **kwargs):
+        ### approach 6- use the pydantic .dict() function to get the dict with pydantic options, add the context at the top and dump to json with modified kwargs
+        pydantic_args = ["include", "exclude", "by_alias", "exclude_defaults", "encoder"]
+        dict_kwargs = dict([(arg, kwargs[arg]) for arg in kwargs.keys() if arg in pydantic_args])
+        json_kwargs = dict([(arg, kwargs[arg]) for arg in kwargs.keys() if arg not in pydantic_args])
+        return json.dumps({"@context": "http://iiif.io/api/presentation/3/context.json", **self.dict(exclude_unset=True, exclude_none=True, **dict_kwargs)}, **json_kwargs)
+    
+    def jsonld_dict(self, **kwargs):
+        pydantic_args = ["include", "exclude", "by_alias", "exclude_defaults", "encoder"]
+        dict_kwargs = dict([(arg, kwargs[arg]) for arg in kwargs.keys() if arg in pydantic_args])
+        return {"@context": "http://iiif.io/api/presentation/3/context.json", **self.dict(exclude_unset=True, exclude_none=True, **dict_kwargs)}

--- a/iiif_prezi3/base.py
+++ b/iiif_prezi3/base.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel
 import json
+
+from pydantic import BaseModel
+
 
 class Base(BaseModel):
 
@@ -27,14 +29,14 @@ class Base(BaseModel):
 
     def json(self, **kwargs):
         return self.jsonld(**kwargs)
-    
+
     def jsonld(self, **kwargs):
-        ### approach 6- use the pydantic .dict() function to get the dict with pydantic options, add the context at the top and dump to json with modified kwargs
+        # approach 6- use the pydantic .dict() function to get the dict with pydantic options, add the context at the top and dump to json with modified kwargs
         pydantic_args = ["include", "exclude", "by_alias", "exclude_defaults", "encoder"]
         dict_kwargs = dict([(arg, kwargs[arg]) for arg in kwargs.keys() if arg in pydantic_args])
         json_kwargs = dict([(arg, kwargs[arg]) for arg in kwargs.keys() if arg not in pydantic_args])
         return json.dumps({"@context": "http://iiif.io/api/presentation/3/context.json", **self.dict(exclude_unset=True, exclude_none=True, **dict_kwargs)}, **json_kwargs)
-    
+
     def jsonld_dict(self, **kwargs):
         pydantic_args = ["include", "exclude", "by_alias", "exclude_defaults", "encoder"]
         dict_kwargs = dict([(arg, kwargs[arg]) for arg in kwargs.keys() if arg in pydantic_args])

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -41,7 +41,7 @@ class BasicTest(unittest.TestCase):
         # test manifest has the helper method
         self.assertEqual(manifest.widest_canvas(), "Maximum canvas width: 200")
 
-        data = json.loads(manifest.json(exclude_unset=True))
+        data = json.loads(manifest.json())
 
         self.assertEqual(manifest.id, 'http://iiif.example.org/prezi/Manifest/0', "Unexpected Manifest id ")
         self.assertEqual(canvas.id, 'http://iiif.example.org/prezi/Canvas/0', "Unexpected Canvas id")


### PR DESCRIPTION
This PR adds the `.jsonld()`and `.jsonld_dict()` functions to the base pydantic model. It also overrides the `.json()` function and replaces it with `.jsonld()`

Closes #27 