### PR TITLE
add tests for auto field helpers

### DIFF
--- a/iiif_prezi3/helpers/auto_fields.py
+++ b/iiif_prezi3/helpers/auto_fields.py
@@ -88,7 +88,7 @@ class AutoId(Auto):
             self._auto_id_types[t] = curr
             slug = f"{t}/{self._auto_id_types[t]}"
         elif auto_type == "uuid":
-            return "urn:uuid:%s" % uuid.uuid4()
+            slug = str(uuid.uuid4())
         elif auto_type == "uuid-per-type":
             t = type(what).__name__
             t = self._type_translation.get(t, t)

--- a/tests/test_helpers_autofields.py
+++ b/tests/test_helpers_autofields.py
@@ -1,7 +1,6 @@
 import unittest
 
-from iiif_prezi3 import Manifest
-from iiif_prezi3 import config
+from iiif_prezi3 import Manifest, config
 
 
 class CanvasHelpersTests(unittest.TestCase):
@@ -14,7 +13,7 @@ class CanvasHelpersTests(unittest.TestCase):
         m = Manifest(label="string")
         self.assertEqual(m.label, str({"none": ["string"]}))
         m = Manifest(label=["string", "string2"])
-        self.assertEqual(m.label, str({"none": ["string", "string2"]}))        
+        self.assertEqual(m.label, str({"none": ["string", "string2"]}))
 
     def test_lang_setattr(self):
         m = Manifest(label="string")

--- a/tests/test_helpers_autofields.py
+++ b/tests/test_helpers_autofields.py
@@ -9,7 +9,7 @@ class CanvasHelpersTests(unittest.TestCase):
         pass
 
     def test_lang_constructor(self):
-        """ Test that label is manipulated during object construction """
+        """Test that label is manipulated during object construction."""
         m = Manifest(label="string")
         self.assertEqual(m.label, str({"none": ["string"]}))
         m = Manifest(label=["string", "string2"])

--- a/tests/test_helpers_autofields.py
+++ b/tests/test_helpers_autofields.py
@@ -1,0 +1,42 @@
+import unittest
+
+from iiif_prezi3 import Manifest
+from iiif_prezi3 import config
+
+
+class CanvasHelpersTests(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_lang_constructor(self):
+        """ Test that label is manipulated during object construction """
+        m = Manifest(label="string")
+        self.assertEqual(m.label, str({"none": ["string"]}))
+        m = Manifest(label=["string", "string2"])
+        self.assertEqual(m.label, str({"none": ["string", "string2"]}))        
+
+    def test_lang_setattr(self):
+        m = Manifest(label="string")
+        m.label = "another string"
+        self.assertEqual(m.label, str({"none": ["another string"]}))
+        m.label = ["string3", "string4"]
+        self.assertEqual(m.label, str({"none": ["string3", "string4"]}))
+
+    def test_id_constructor(self):
+        m = Manifest(label="a")
+        self.assertEqual(m.id, 'http://example.org/iiif/1')
+
+    def test_lang_config(self):
+        curr = config.configs['helpers.auto_fields.AutoLang'].auto_lang
+        config.configs['helpers.auto_fields.AutoLang'].auto_lang = "de"
+        m = Manifest(label="german")
+        self.assertEqual(m.label, str({"de": ["german"]}))
+        config.configs['helpers.auto_fields.AutoLang'].auto_lang = curr
+
+    def test_id_config(self):
+        curr = config.configs['helpers.auto_fields.AutoId'].auto_type
+        config.configs['helpers.auto_fields.AutoId'].auto_type = "uuid"
+        m = Manifest(label="string")
+        self.assertEqual(len(m.id), 60)
+        config.configs['helpers.auto_fields.AutoId'].auto_type = curr

--- a/tests/test_helpers_autofields.py
+++ b/tests/test_helpers_autofields.py
@@ -3,7 +3,7 @@ import unittest
 from iiif_prezi3 import Manifest, config
 
 
-class CanvasHelpersTests(unittest.TestCase):
+class AutoFieldsHelpersTests(unittest.TestCase):
 
     def setUp(self):
         pass

--- a/tests/test_helpers_autofields.py
+++ b/tests/test_helpers_autofields.py
@@ -16,6 +16,7 @@ class CanvasHelpersTests(unittest.TestCase):
         self.assertEqual(m.label, str({"none": ["string", "string2"]}))
 
     def test_lang_setattr(self):
+        """Test that label is manipulated during property setting."""
         m = Manifest(label="string")
         m.label = "another string"
         self.assertEqual(m.label, str({"none": ["another string"]}))
@@ -23,10 +24,12 @@ class CanvasHelpersTests(unittest.TestCase):
         self.assertEqual(m.label, str({"none": ["string3", "string4"]}))
 
     def test_id_constructor(self):
+        """Test that id is added during object construction."""
         m = Manifest(label="a")
         self.assertEqual(m.id, 'http://example.org/iiif/1')
 
     def test_lang_config(self):
+        """Test that lang config is respected."""
         curr = config.configs['helpers.auto_fields.AutoLang'].auto_lang
         config.configs['helpers.auto_fields.AutoLang'].auto_lang = "de"
         m = Manifest(label="german")
@@ -34,6 +37,7 @@ class CanvasHelpersTests(unittest.TestCase):
         config.configs['helpers.auto_fields.AutoLang'].auto_lang = curr
 
     def test_id_config(self):
+        """Test that id config is respected."""
         curr = config.configs['helpers.auto_fields.AutoId'].auto_type
         config.configs['helpers.auto_fields.AutoId'].auto_type = "uuid"
         m = Manifest(label="string")


### PR DESCRIPTION
Add tests for auto_field helper, and make uuid a slug, not a full URN (which is invalid according to pydantic)