### PR TITLE
Update monkeypatch to handle list of Schema classes

### DIFF
--- a/iiif_prezi3/loader.py
+++ b/iiif_prezi3/loader.py
@@ -32,11 +32,21 @@ def load_extension(path):
         return
 
 
-def monkeypatch_schema(schema_class, patch_classes):
-    schema_bases = list(schema_class.__bases__)
-    if type(patch_classes) == list:
-        for c in patch_classes:
-            schema_bases.append(c)
+def monkeypatch_schema(schema_classes, patch_classes):
+    if type(schema_classes) == list:
+        for schema_class in schema_classes:
+            schema_bases = list(schema_class.__bases__)
+            if type(patch_classes) == list:
+                for c in patch_classes:
+                    schema_bases.append(c)
+            else:
+                schema_bases.append(patch_classes)
+            schema_class.__bases__ = tuple(schema_bases)
     else:
-        schema_bases.append(patch_classes)
-    schema_class.__bases__ = tuple(schema_bases)
+        schema_bases = list(schema_classes.__bases__)
+        if type(patch_classes) == list:
+            for c in patch_classes:
+                schema_bases.append(c)
+        else:
+            schema_bases.append(patch_classes)
+        schema_classes.__bases__ = tuple(schema_bases)


### PR DESCRIPTION
This updates the monkeypatcher to allow passing a list of Schema objects as well as a single one.

```python
from ..loader import monkeypatch_schema
from ..skeleton import Manifest, Canvas

class ExampleHelper:
    def example_helper(self):
        return "First Example"

class ExampleHelper2:
    def example_helper2(self):
        return "Second example

monkeypatch_schema(Manifest, ExampleHelper)
monkeypatch_schema([Manifest, Canvas], ExampleHelper2)
```

