### PR TITLE
Correct dev requirements path in cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.dev.txt') }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
I noticed the cache key had the wrong filename for the dev requirements. 

Although I can't tell if the dev requirements are being used anywhere... should they be?