### PR TITLE
Basic mkdocs documentation setup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,13 +15,13 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.dev.txt') }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install -e '.[dev]'
+          pip install -e '.[docs]'
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+
 
 jobs:
   build:
@@ -23,9 +25,15 @@ jobs:
           pip install -e .
           pip install -e '.[docs]'
 
+      # build docs in strict mode as a check for pull requests
+      - name: Build docs (strict mode)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: mkdocs build --strict
+
+      # build docs and publish on push to main
       - name: Deploy docs
+        if: ${{ github.event_name == 'push' }}
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: mkdocs.yml
-          EXTRA_PACKAGES: build-base

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,8 +7,8 @@ on:
 
 
 jobs:
-  build:
-    name: Deploy docs
+  docs:
+    name: docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Publish docs via GitHub Pages
+name: docs
 on:
   push:
     branches:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install -e '.[dev]'
+
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG_FILE: mkdocs.yml
+          EXTRA_PACKAGES: build-base

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: ${{ env.pythonLocation }}
+          path: ~/.cache/pip-docs
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements.dev.txt') }}
 
       - name: Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ If submitting a pull request:
    * Follow [PEP8](https://www.python.org/dev/peps/pep-0008/) and [PEP257](https://www.python.org/dev/peps/pep-0257/). These will be required in the CI builds.
    * Don't repeat code.
    * Cover the code with tests.
+   * Use [Google style docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) for any code documentation you add.
 
 ## Developing helpers
 
@@ -27,3 +28,8 @@ To develop a helper you should follow the documentation [here](https://github.co
  * A fixture which demonstrates your use case in the [fixtures directory](https://github.com/iiif-prezi/iiif-prezi3/tree/main/tests/fixtures).
 
 Please submit your pull request to this repository and one of the library committers will merge it into the main if it fits these requirements.
+
+
+## Docs
+
+To build and view the documentation locally, install requirements with `pip install -e '.[docs]'` and then run `mkdocs serve`.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If you have an existing IIIF Presentation v3 Manifest, you can load it via the b
 
 Published extensions from the [IIIF Registry of Extensions](https://iiif.io/api/extension/) are included with the package, and can be loaded using the `iiif_prezi3.load_bundled_extensions()` method.
 
-Called without argument, this method will load all bundled extensions listed in the [iiif_prezi3/config/extensions.json](iiif_prezi3/config/extensions.json) file. If you wish to only load selected extensions from those available bundled with the library, you can pass either the path to a JSON file, or a list of extension names as an argument to the function:
+Called without argument, this method will load all bundled extensions listed in the  [iiif_prezi3/config/extensions.json](https://github.com/iiif-prezi/iiif-prezi3/blob/main/iiif_prezi3/config/extensions.json) file. If you wish to only load selected extensions from those available bundled with the library, you can pass either the path to a JSON file, or a list of extension names as an argument to the function:
 ```
 >>> import iiif_prezi3
 >>> iiif_prezi3.load_bundled_extensions(extensions="/path/to/chosen_extensions.json")

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/docs/code.md
+++ b/docs/code.md
@@ -1,0 +1,3 @@
+# Code reference
+
+::: iiif_prezi3

--- a/iiif_prezi3/helpers/add_label.py
+++ b/iiif_prezi3/helpers/add_label.py
@@ -14,8 +14,6 @@ class AddLabel:
             language (str): An optional language for the labels. If not provided
                 it will default using the AutoLang configuration.
 
-        Returns:
-            None
         """
         if not self.label:
             if not language:

--- a/iiif_prezi3/helpers/canvas_helpers.py
+++ b/iiif_prezi3/helpers/canvas_helpers.py
@@ -3,21 +3,21 @@ from ..skeleton import Annotation, AnnotationPage, Canvas, ResourceItem
 
 
 class AddImageToCanvas:
-    """Adds an image to an existing canvas.
-
-    Args:
-        image_url (str): An HTTP URL which points to the image.
-        anno_id (str): An HTTP URL for the annotation to which the image will be
-            attached.
-        anno_page_id (str): An HTTP URL for the annotation page to which the
-            annotation will be attached.
-
-    Returns:
-        anno_page (iiif-prezi3.skeleton.AnnotationPage): the AnnotationPage with
-            an Annotation and ResourceItem attached.
-    """
 
     def add_image(self, image_url, anno_id=None, anno_page_id=None):
+        """Adds an image to an existing canvas.
+
+        Args:
+            image_url (str): An HTTP URL which points to the image.
+            anno_id (str): An HTTP URL for the annotation to which the image will be
+                attached.
+            anno_page_id (str): An HTTP URL for the annotation page to which the
+                annotation will be attached.
+
+        Returns:
+            anno_page (iiif-prezi3.skeleton.AnnotationPage): the AnnotationPage with
+                an Annotation and ResourceItem attached.
+        """
         body = ResourceItem(id=image_url, type='Image')
         annotation = Annotation(id=anno_id, body=body, target=image_url, motivation='painting', type='Annotation')
         anno_page = AnnotationPage(id=anno_page_id, type='AnnotationPage', items=[annotation])

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: iiif-prezi3
 
 nav:
+    - 'README': README.md
     - 'Getting started':
         - 'Using iiifprezi3 without helper methods': 'getting-started-using-iiifprezi3-without-helpermethods.md'
         - 'add-reference-to-manifest-inside-a-collection.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: iiif-prezi3
+
+nav:
+    - 'Getting started':
+        - 'Using iiifprezi3 without helper methods': 'getting-started-using-iiifprezi3-without-helpermethods.md'
+        - 'add-reference-to-manifest-inside-a-collection.md'
+    - Technical:
+        - 'generate-schema.md'
+        - 'write-helper-method.md'
+        - code.md
+
+theme:
+  name: material
+
+plugins:
+  - search
+  - mkdocstrings

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,12 @@ REQUIREMENTS = [
     "pydantic"
 ]
 
+DOCS_REQUIREMENTS = [
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocstrings",
+]
+
 # Setting up
 setup(
     name='iiif-prezi3',
@@ -46,4 +52,7 @@ setup(
     url='https://github.com/iiif-prezi/iiif-prezi3',
     license='LICENSE',
     install_requires=REQUIREMENTS,
+     extras_require={
+        "docs": DOCS_REQUIREMENTS,
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = [
 DOCS_REQUIREMENTS = [
     "mkdocs",
     "mkdocs-material",
-    "mkdocstrings",
+    "mkdocstrings-python",
 ]
 
 # Setting up


### PR DESCRIPTION
this pr adds basic documentation setup

- docs dependencies added as extra / optional install in setup.py
- very basic `mkdocs` setup; pulled in the existing `docs/*.md` files, linked the main readme to be the index of the docs site, added a code reference file to generate docs from code docstrings using google format
- added notes to contributing file about docstring format and instructions for building docs locally
- github action to publish mkdocs —based on https://github.com/marketplace/actions/deploy-mkdocs ; not sure how to test this before merging! at minimum a maintainer will need to configure a `GITHUB_TOKEN` secret to allow the deploy

should be possible to create PR check to confirm documentation builds correctly, and maybe even check documentation coverage, but I'm less familiar with mkdocs than sphinx