### PR TITLE
Fix accidental exclusion of default values

### DIFF
--- a/iiif_prezi3/base.py
+++ b/iiif_prezi3/base.py
@@ -50,12 +50,12 @@ class Base(BaseModel):
 
     def jsonld(self, **kwargs):
         # approach 6- use the pydantic .dict() function to get the dict with pydantic options, add the context at the top and dump to json with modified kwargs
-        pydantic_args = ["include", "exclude", "by_alias", "exclude_defaults", "encoder"]
+        pydantic_args = ["include", "exclude", "by_alias", "encoder"]
         dict_kwargs = dict([(arg, kwargs[arg]) for arg in kwargs.keys() if arg in pydantic_args])
         json_kwargs = dict([(arg, kwargs[arg]) for arg in kwargs.keys() if arg not in pydantic_args])
-        return json.dumps({"@context": "http://iiif.io/api/presentation/3/context.json", **self.dict(exclude_unset=True, exclude_none=True, **dict_kwargs)}, **json_kwargs)
+        return json.dumps({"@context": "http://iiif.io/api/presentation/3/context.json", **self.dict(exclude_unset=False, exclude_defaults=False, exclude_none=True, **dict_kwargs)}, **json_kwargs)
 
     def jsonld_dict(self, **kwargs):
-        pydantic_args = ["include", "exclude", "by_alias", "exclude_defaults", "encoder"]
+        pydantic_args = ["include", "exclude", "by_alias", "encoder"]
         dict_kwargs = dict([(arg, kwargs[arg]) for arg in kwargs.keys() if arg in pydantic_args])
-        return {"@context": "http://iiif.io/api/presentation/3/context.json", **self.dict(exclude_unset=True, exclude_none=True, **dict_kwargs)}
+        return {"@context": "http://iiif.io/api/presentation/3/context.json", **self.dict(exclude_unset=False, exclude_defaults=False, exclude_none=True, **dict_kwargs)}


### PR DESCRIPTION
The inclusion of `exclude_unset=True` in the JSON producing functions was preventing non-modified defaults (such as `type` from being included in the JSON output.

This PR fixes that, and also explicitly sets `exclude_defaults` to `False` and prevents it from being overridden by the kwargs.