### PR TITLE
Range and thumbnail fix

### DIFF
--- a/iiif_prezi3/helpers/to_reference.py
+++ b/iiif_prezi3/helpers/to_reference.py
@@ -8,7 +8,7 @@ class ToReference:
     def to_reference(self):
         """Returns a Reference object that points to the calling object."""
         # Only try to set thumbnail if it's a Class that can have one
-        if isinstance(self, (Collection, Manifest, Canvas)):
+        if isinstance(self, (Collection, Manifest, Canvas, AnnotationPage, Annotation, AnnotationCollection, Range)):
             thumbnail = self.thumbnail
         else:
             thumbnail = None

--- a/iiif_prezi3/helpers/to_reference.py
+++ b/iiif_prezi3/helpers/to_reference.py
@@ -1,6 +1,6 @@
 from ..loader import monkeypatch_schema
-from ..skeleton import (AnnotationCollection, AnnotationPage, Canvas,
-                        Collection, Manifest, Reference)
+from ..skeleton import (Annotation, AnnotationCollection, AnnotationPage,
+                        Canvas, Collection, Manifest, Range, Reference)
 
 
 class ToReference:
@@ -21,4 +21,4 @@ class ToReference:
         return Reference(id=self.id, label=self.label, type=self.type, thumbnail=thumbnail)
 
 
-monkeypatch_schema([Manifest, AnnotationPage, Collection, AnnotationCollection, Canvas], ToReference)
+monkeypatch_schema([Manifest, AnnotationPage, Collection, AnnotationCollection, Canvas, Range], ToReference)


### PR DESCRIPTION
Allows Ranges to be added by reference
Allows other item types to have thumbnails (NB: this will make some tests fail until https://github.com/IIIF/presentation-validator/pull/151 is merged, and the `skeleton.py` file regenerated)