### PR TITLE
Bump GH action versions

### DIFF
--- a/.github/workflows/PyPi.yml
+++ b/.github/workflows/PyPi.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 

--- a/.github/workflows/TestPyPi.yml
+++ b/.github/workflows/TestPyPi.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
     name: Python ${{ matrix.python-version }} sample
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -36,26 +36,3 @@ jobs:
 
       - name: install coveralls
         run: pip install coveralls
-
-
-     # - name: Generate coverage
-     #   run: coverage run --include=iiif-presentation-validator.py setup.py test
-
-      #- name: Upload coverage data to coveralls.io
-      #  run: coveralls --service=github
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #    COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
-      #    COVERALLS_PARALLEL: true
-
- # Coveralls:
- #   needs: build
- #   runs-on: ubuntu-latest
- #   container: python:3-slim
- #   steps:
- #   - name: Coveralls Finished
- #     run: |
- #       pip3 install --upgrade coveralls
- #       coveralls --service=github --finish
- #     env:
- #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip-docs
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}


### PR DESCRIPTION
Bumps GitHub actions versions:
- `actions/checkout` to v3
- `actions/setup-python` to v4
- `actions/cache` to v3

fixes #99 