### PR TITLE
Correct name of function in `make_canvas_from_iiif` helper

### DIFF
--- a/iiif_prezi3/helpers/create_canvas_from_iiif.py
+++ b/iiif_prezi3/helpers/create_canvas_from_iiif.py
@@ -51,7 +51,7 @@ class CreateCanvasFromIIIF:
         return canvas
 
     def make_canvas_from_iiif(self, url, **kwargs):
-        canvas = self.create_canvas_from_IIIF(url, **kwargs)
+        canvas = self.create_canvas_from_iiif(url, **kwargs)
 
         self.add_item(canvas)
 


### PR DESCRIPTION
Uses the correct name for `create_canvas_from_iiif()` in `make_canvas_from_iiif()`.

fixes #110 