### PR TITLE
Target canvas id

### DIFF
--- a/iiif_prezi3/helpers/canvas_helpers.py
+++ b/iiif_prezi3/helpers/canvas_helpers.py
@@ -19,7 +19,7 @@ class AddImageToCanvas:
                 an Annotation and ResourceItem attached.
         """
         body = ResourceItem(id=image_url, type='Image')
-        annotation = Annotation(id=anno_id, body=body, target=image_url, motivation='painting', type='Annotation')
+        annotation = Annotation(id=anno_id, body=body, target=self.id, motivation='painting', type='Annotation')
         anno_page = AnnotationPage(id=anno_page_id, type='AnnotationPage', items=[annotation])
         if not self.items:
             self.items = list()

--- a/tests/test_canvas_helpers.py
+++ b/tests/test_canvas_helpers.py
@@ -12,5 +12,5 @@ class CanvasHelpersTests(unittest.TestCase):
         self.assertTrue(isinstance(anno_page, AnnotationPage), '`add_image` should return an AnnotationPage')
         self.assertEqual(len(self.canvas.items), 1)
         self.assertEqual(anno_page.items[0].id, 'http://iiif.example.org/prezi/Annotation/0')
-        self.assertEqual(anno_page.items[0].target, 'http://iiif.example.org/prezi/Image/0')
+        self.assertEqual(anno_page.items[0].target, 'http://iiif.example.org/prezi/Canvas/0')
         self.assertEqual(anno_page.items[0].dict()["body"]["id"], 'http://iiif.example.org/prezi/Image/0')


### PR DESCRIPTION
Changes target of image to (correctly) target Canvas URI rather than the image URI. Also updates tests.

Fixes #108 