### PR TITLE
Fix flake8 config to work with flake8 6.0.0

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,13 +11,23 @@ docstring-convention = google
 import-order-style = pep8
 max-complexity = 10
 ignore =
-	D100 # Missing docstring in public module
-	D101 # Missing docstring in public class
-	D102 # Missing docstring in public method
-	D103 # Missing docstring in public function
-	D104 # Missing docstring in public package
-	D105 # Missing docstring in magic method
-	D106 # Missing docstring in public nested class
-	D107 # Missing docstring in __init__
-	E501 # Line too long
-  F722 # syntax error in forward annotation
+ 	# Missing docstring in public module
+	D100
+	# Missing docstring in public class
+	D101
+	# Missing docstring in public method
+	D102
+	# Missing docstring in public function
+	D103
+	# Missing docstring in public package
+	D104
+	# Missing docstring in magic method
+	D105
+	# Missing docstring in public nested class
+	D106
+	# Missing docstring in __init__
+	D107
+	# Line too long
+	E501
+	# syntax error in forward annotation
+	F722


### PR DESCRIPTION
Moves comments in the `ignore` section to their own lines

Closes #118 