### PR TITLE
Configure python as default handler for mkdocstrings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,4 +15,5 @@ theme:
 
 plugins:
   - search
-  - mkdocstrings
+  - mkdocstrings:
+      default_handler: python


### PR DESCRIPTION
to address #130

I looked at this briefly locally — it looks like we need to configure the default handler for `mkdocstrings` to be `python`

Attaching a screenshot of the beginning of the code docs page that I built locally with this config

![Screen Shot 2022-12-05 at 5 39 47 PM](https://user-images.githubusercontent.com/691231/205758342-b30511c9-af89-4125-ba40-d80e2a847ca7.png)
