### PR TITLE
Embed cookbook .py files in mkdocs

### DIFF
--- a/docs/recipes/0118-multivalue.md
+++ b/docs/recipes/0118-multivalue.md
@@ -1,0 +1,11 @@
+# Displaying Multiple Values with Language Maps
+|              | **Cookbook URLs** |
+| ------------ | ----------------- |
+| **Recipe:**  |[https://iiif.io/api/cookbook/recipe/0118_multivalue/](https://iiif.io/api/cookbook/recipe/0118_multivalue/)|
+| **JSON-LD:** |[https://iiif.io/api/cookbook/recipe/0118_multivalue/manifest.json](https://iiif.io/api/cookbook/recipe/0118_multivalue/manifest.json)|
+
+## Method 1 - Construct the language dictionaries during object creation
+
+```py title="0118_multivalue.py"
+--8<-- "docs/recipes/0118_multivalue.py"
+```

--- a/docs/recipes/0118_multivalue.py
+++ b/docs/recipes/0118_multivalue.py
@@ -1,0 +1,18 @@
+from iiif_prezi3 import Manifest, KeyValueString
+
+manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0118_multivalue/manifest.json",
+                    label={"fr": ["Arrangement en gris et noir no 1"]})
+manifest.metadata = [
+    KeyValueString(label={"en": ["Alternative titles"]},
+                   value={"en": ["Whistler's Mother","Arrangement in Grey and Black No. 1"],
+                          "fr": ["Portrait de la mère de l'artiste","La Mère de Whistler"]})
+]
+manifest.summary = {"en": ["A painting in oil on canvas created by the American-born painter James McNeill Whistler, in 1871."],
+                    "fr": ["Arrangement en gris et noir n°1, also called Portrait de la mère de l'artiste."]}
+
+canvas = manifest.make_canvas_from_iiif(url="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1b/Whistlers_Mother_high_res.jpg/1114px-Whistlers_Mother_high_res.jpg",
+                                        id="https://iiif.io/api/cookbook/recipe/0118_multivalue/canvas/1")
+canvas.items[0].id = "https://iiif.io/api/cookbook/recipe/0118_multivalue/canvas/1/page/1"
+canvas.items[0].items[0].id = "https://iiif.io/api/cookbook/recipe/0118_multivalue/canvas/1/page/1/annotation/1"
+
+print(manifest.json(indent=2))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,8 @@ nav:
         - 'generate-schema.md'
         - 'write-helper-method.md'
         - code.md
+    - Cookbook recipes:
+        - 'recipes/0118-multivalue.md'
 
 theme:
   name: material
@@ -17,6 +19,7 @@ markdown_extensions:
   - pymdownx.highlight:
       use_pygments: true
   - pymdownx.superfences
+  - pymdownx.snippets
 
 plugins:
   - search


### PR DESCRIPTION
This should ease the process of reusing cookbook recipes.

We write the recipe in .py file and then we embed it using `mkdocs-material` extension snippets: 
https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#embedding-external-files

Shall we keep the examples in the doc folder or create an examples folder at the root of the project?

I use this approach: 
https://github.com/giacomomarchioro/pyIIIFpres/blob/8486e0cb7d870788c23de5cf2da105bc602b0604/tests/integration/tests.py#L168 

But maybe Mike can come up with something more clever.

