### PR TITLE
Adds args for intermediate objects

### DIFF
--- a/iiif_prezi3/helpers/annotation_helpers.py
+++ b/iiif_prezi3/helpers/annotation_helpers.py
@@ -36,6 +36,7 @@ class AnnotationHelpers:
         """Creates an annotation object and adds it to the annotations property using .add_annotation().
 
         Args:
+            anno_page_id (str): An HTTP URL for the annotation page to which the annotation will be attached. 
             **kwargs (): see Annotation.
         """
         annotation = Annotation(**kwargs)

--- a/iiif_prezi3/helpers/annotation_helpers.py
+++ b/iiif_prezi3/helpers/annotation_helpers.py
@@ -15,7 +15,7 @@ class AnnotationHelpers:
             anno_page_id (str): An HTTP URL for the annotation page to which the annotation will be attached.
 
         Returns:
-            annotation (Annotation)
+            annotation (Annotation): the Annotation attached to the AnnotationPage.
 
         """
         if not self.annotations:

--- a/iiif_prezi3/helpers/annotation_helpers.py
+++ b/iiif_prezi3/helpers/annotation_helpers.py
@@ -5,20 +5,25 @@ from ..skeleton import (Annotation, AnnotationPage, Canvas, Collection,
 
 class AnnotationHelpers:
 
-    def add_annotation(self, annotation):
+    def add_annotation(self, annotation, anno_page_id=None):
         """Adds the annotation object to the (AnnotationPage object in the) annotations property.
 
-        Args:
-          annotation (Annotation): the Annotation to add
-
         Creates an AnnotationPage object if it doesn't exist.
+
+        Args:
+            annotation (Annotation): the Annotation to add
+            anno_page_id (str): An HTTP URL for the annotation page to which the annotation will be attached.
+
+        Returns:
+            annotation (Annotation)
+
         """
         if not self.annotations:
             self.annotations = list()
 
         if len(self.annotations) == 0:
             # add empty AnnotationPage
-            anno_page = AnnotationPage(items=[])
+            anno_page = AnnotationPage(id=anno_page_id, items=[])
             self.annotations.append(anno_page)
         else:
             anno_page = self.annotations[0]

--- a/iiif_prezi3/helpers/annotation_helpers.py
+++ b/iiif_prezi3/helpers/annotation_helpers.py
@@ -36,7 +36,7 @@ class AnnotationHelpers:
         """Creates an annotation object and adds it to the annotations property using .add_annotation().
 
         Args:
-            anno_page_id (str): An HTTP URL for the annotation page to which the annotation will be attached. 
+            anno_page_id (str): An HTTP URL for the annotation page to which the annotation will be attached.
             **kwargs (): see Annotation.
         """
         annotation = Annotation(**kwargs)

--- a/iiif_prezi3/helpers/annotation_helpers.py
+++ b/iiif_prezi3/helpers/annotation_helpers.py
@@ -32,13 +32,13 @@ class AnnotationHelpers:
 
         return annotation
 
-    def make_annotation(self, **kwargs):
+    def make_annotation(self, anno_id=None, **kwargs):
         """Creates an annotation object and adds it to the annotations property using .add_annotation().
 
         Args:
             **kwargs (): see Annotation.
         """
-        annotation = Annotation(**kwargs)
+        annotation = Annotation(id=anno_id, **kwargs)
         self.add_annotation(annotation)
         return annotation
 

--- a/iiif_prezi3/helpers/annotation_helpers.py
+++ b/iiif_prezi3/helpers/annotation_helpers.py
@@ -32,14 +32,14 @@ class AnnotationHelpers:
 
         return annotation
 
-    def make_annotation(self, anno_id=None, **kwargs):
+    def make_annotation(self, anno_page_id=None, **kwargs):
         """Creates an annotation object and adds it to the annotations property using .add_annotation().
 
         Args:
             **kwargs (): see Annotation.
         """
-        annotation = Annotation(id=anno_id, **kwargs)
-        self.add_annotation(annotation)
+        annotation = Annotation(**kwargs)
+        self.add_annotation(annotation, anno_page_id=anno_page_id)
         return annotation
 
 

--- a/iiif_prezi3/helpers/create_canvas_from_iiif.py
+++ b/iiif_prezi3/helpers/create_canvas_from_iiif.py
@@ -7,11 +7,19 @@ from ..skeleton import (Annotation, AnnotationPage, Canvas, Manifest,
 class CreateCanvasFromIIIF:
     # should probably be added to canvas helpers
 
-    def create_canvas_from_iiif(self, url, **kwargs):
+    def create_canvas_from_iiif(self, url, anno_id=None, anno_page_id=None, **kwargs):
         """Create a canvas from a IIIF Image URL.
 
-        Creates a canvas from a IIIF Image service passing any
-        kwargs to the Canvas. Returns a Canvas object
+        Creates a canvas from a IIIF Image service passing any kwargs to the Canvas.
+
+        Args:
+            url (str): An HTTP URL at which at a IIIF Image is available.
+            anno_id (str): An HTTP URL for the annotation to which the image will be attached.
+            anno_page_id (str): An HTTP URL for the annotation page to which the annotation will be attached.
+            **kwargs (): see Canvas
+
+        Returns:
+            canvas (Canvas)
 
         """
         canvas = Canvas(**kwargs)
@@ -40,9 +48,9 @@ class CreateCanvasFromIIIF:
             body.id = f'{infoJson["id"]}/full/max/0/default.jpg'
             body.format = "image/jpeg"
 
-        annotation = Annotation(motivation='painting', body=body, target=canvas.id)
+        annotation = Annotation(id=anno_id, motivation='painting', body=body, target=canvas.id)
 
-        annotationPage = AnnotationPage()
+        annotationPage = AnnotationPage(id=anno_page_id)
         annotationPage.add_item(annotation)
 
         canvas.add_item(annotationPage)

--- a/iiif_prezi3/helpers/create_canvas_from_iiif.py
+++ b/iiif_prezi3/helpers/create_canvas_from_iiif.py
@@ -19,7 +19,7 @@ class CreateCanvasFromIIIF:
             **kwargs (): see Canvas
 
         Returns:
-            canvas (Canvas)
+            canvas (Canvas): the Canvas created from the IIIF Image.
 
         """
         canvas = Canvas(**kwargs)


### PR DESCRIPTION
Adds arguments for Annotation and AnnotationPage.

I didn't add **kwargs for `AnnotationHelpers.add_annotation` because we're already passing in a pre-fab Annotation object, so since we're not creating an Annotation from scratch it makes less sense to do that (IMO). Happy to be contradicted though.

Fixes #111 