### PR TITLE
Switch tox to using package dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
     name: Python ${{ matrix.python-version }} sample

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+          check-latest: true
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox tox-gh-actions
+          python -m pip install cffi tox tox-gh-actions
 
       - name: Test with tox
         run: tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-          check-latest: true
 
       - uses: actions/cache@v3
         with:
@@ -30,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cffi tox tox-gh-actions
+          python -m pip install tox tox-gh-actions
 
       - name: Test with tox
         run: tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-u22
 
       - name: Install dependencies
         run: |

--- a/iiif_prezi3/base.py
+++ b/iiif_prezi3/base.py
@@ -2,6 +2,7 @@ import json
 
 from pydantic import AnyUrl, BaseModel
 
+
 class Base(BaseModel):
 
     class Config:
@@ -10,7 +11,7 @@ class Base(BaseModel):
         copy_on_model_validation = False
         smart_union = True
         # Allow us to use the field name like service.id rather than service.@id
-        allow_population_by_field_name = True 
+        allow_population_by_field_name = True
 
     def __getattribute__(self, prop):
         val = super(Base, self).__getattribute__(prop)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -88,6 +88,5 @@ class BasicTest(unittest.TestCase):
         self.assertEqual(manifest.label['en'][0], 'default label', 'Unexpected label for manifest')
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_canvas_helpers.py
+++ b/tests/test_canvas_helpers.py
@@ -9,9 +9,9 @@ class CanvasHelpersTests(unittest.TestCase):
 
     def test_add_image(self):
         anno_page = self.canvas.add_image(
-                'http://iiif.example.org/prezi/Image/0', 
-                'http://iiif.example.org/prezi/Annotation/0', 
-                height=400)
+            'http://iiif.example.org/prezi/Image/0',
+            'http://iiif.example.org/prezi/Annotation/0',
+            height=400)
         self.assertTrue(isinstance(anno_page, AnnotationPage), '`add_image` should return an AnnotationPage')
         self.assertEqual(len(self.canvas.items), 1)
         self.assertEqual(anno_page.items[0].id, 'http://iiif.example.org/prezi/Annotation/0')

--- a/tests/test_create_canvas_from_iiif.py
+++ b/tests/test_create_canvas_from_iiif.py
@@ -75,25 +75,25 @@ class CreateCanvasFromIIIFTests(unittest.TestCase):
         mockrequest_get.return_value = mockresponse
         # set mock to return minimal image api response
         mockresponse.json.return_value = {
-          "@context": "http://iiif.io/api/image/2/context.json",
-          "@id": "https://iiif.io/api/image/2.1/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
-          "height": 3024,
-          "profile": [
-            "http://iiif.io/api/image/2/level1.json",
-            {
-              "formats": [ "jpg", "png" ],
-              "qualities": [ "default", "color", "gray" ]
-            }
-          ],
-          "protocol": "http://iiif.io/api/image",
-          "tiles": [
-            {
-              "height": 512,
-              "scaleFactors": [ 1, 2, 4 ],
-              "width": 512
-            }
-          ],
-          "width": 4032
+            "@context": "http://iiif.io/api/image/2/context.json",
+            "@id": "https://iiif.io/api/image/2.1/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
+            "height": 3024,
+            "profile": [
+                "http://iiif.io/api/image/2/level1.json",
+                {
+                    "formats": ["jpg", "png"],
+                    "qualities": ["default", "color", "gray"]
+                }
+            ],
+            "protocol": "http://iiif.io/api/image",
+            "tiles": [
+                {
+                    "height": 512,
+                    "scaleFactors": [1, 2, 4],
+                    "width": 512
+                }
+            ],
+            "width": 4032
         }
 
         canvas = self.manifest.create_canvas_from_iiif(image_info_url, label={'en': ['Canvas label']})
@@ -125,4 +125,3 @@ class CreateCanvasFromIIIFTests(unittest.TestCase):
         self.assertEqual(service.id, image_id)
         self.assertEqual(service.profile, "http://iiif.io/api/image/2/level1.json")
         self.assertEqual(service.type, "ImageService2")
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py37, py38, py39, py310, py311, linting
-skipsdist = True
 
 [gh-actions]
 python =
@@ -11,24 +10,12 @@ python =
     3.11: py311
 
 [testenv]
-deps =
-  pydantic
-  Pillow
-  requests
-
-skip_install = True
 commands =
 	python -m unittest discover -s tests
 
 [testenv:linting]
 basepython = python3
-deps =
-  autopep8
-  isort
-  flake8-docstrings
-  flake8-isort
-  flake8
-skip_install = true
+extras = dev
 commands =
   isort .
   autopep8 --in-place --recursive --exclude skeleton.py --ignore E501 .


### PR DESCRIPTION
Allowing tox to build the sdist means it deals with installing the dependencies in each environment. Combined this with manually specifying that the `dev` extras should be installed in the linter environment.

This should mean we no longer need to keep tox.ini up to date when our requirements change and so removes both workload/remembering and potential issues caused by differing versions when developing and testing (such as the Pydantic `deep_copy` issue) :tada: 

Closes #98 