### PR TITLE
Update getattribute handling to work with root-having items inside a list

### DIFF
--- a/iiif_prezi3/base.py
+++ b/iiif_prezi3/base.py
@@ -15,7 +15,16 @@ class Base(BaseModel):
         allow_population_by_field_name = True
 
     def __getattribute__(self, prop):
-        val = super(Base, self).__getattribute__(prop)
+        try:
+            val = super(Base, self).__getattribute__(prop)
+        except AttributeError:
+            super_fields = super(Base, self).__getattribute__("__fields__")
+            if "__root__" in super_fields:
+                obj = super(Base, self).__getattribute__("__root__")
+                val = super(Base, obj).__getattribute__(prop)
+            else:
+                raise
+
         # __root__ is a custom pydantic thing
         if hasattr(val, '__root__'):
             if type(val.__root__) in [AnyUrl]:


### PR DESCRIPTION
Please see extensive discussion in Slack starting here: https://iiif.slack.com/archives/C04EWD70FCH/p1678557314842839

tl;dr - there was an edge case in the handling of our current workaround to make Pydantic's `__root__` construct invisible that prevented it (nested roots with a list at the property level) and this fixes that