### PR TITLE
Update recipes to use a `base_url` variable to improve readability

### DIFF
--- a/docs/recipes/scripts/0001-mvm-image-method1.py
+++ b/docs/recipes/scripts/0001-mvm-image-method1.py
@@ -1,12 +1,13 @@
 from iiif_prezi3 import Manifest, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0001-mvm-image"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json", label="Single Image Example")
-canvas = manifest.make_canvas(id="https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1", height=1800, width=1200)
+manifest = Manifest(id=f"{base_url}/manifest.json", label="Single Image Example")
+canvas = manifest.make_canvas(id=f"{base_url}/canvas/p1", height=1800, width=1200)
 anno_page = canvas.add_image(image_url="http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
-                             anno_page_id="https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1",
-                             anno_id="https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image",
+                             anno_page_id=f"{base_url}/page/p1/1",
+                             anno_id=f"{base_url}/annotation/p0001-image",
                              format="image/png",
                              height=1800,
                              width=1200

--- a/docs/recipes/scripts/0001-mvm-image-method2.py
+++ b/docs/recipes/scripts/0001-mvm-image-method2.py
@@ -1,16 +1,17 @@
 from iiif_prezi3 import Manifest, Canvas, AnnotationPage, Annotation, ResourceItem, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0001-mvm-image"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json", label="Single Image Example")
-canvas = Canvas(id="https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1", height=1800, width=1200)
+manifest = Manifest(id=f"{base_url}/manifest.json", label="Single Image Example")
+canvas = Canvas(id=f"{base_url}/canvas/p1", height=1800, width=1200)
 anno_body = ResourceItem(id="http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
                          type="Image",
                          format="image/png",
                          height=1800,
                          width=1200)
-anno_page = AnnotationPage(id="https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1")
-anno = Annotation(id="https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image",
+anno_page = AnnotationPage(id=f"{base_url}/page/p1/1")
+anno = Annotation(id=f"{base_url}/annotation/p0001-image",
                   motivation="painting",
                   body=anno_body,
                   target=canvas.id)

--- a/docs/recipes/scripts/0002-mvm-audio-method1.py
+++ b/docs/recipes/scripts/0002-mvm-audio-method1.py
@@ -1,15 +1,16 @@
 from iiif_prezi3 import Manifest, AnnotationPage, Annotation, ResourceItem, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0002-mvm-audio"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json", label="Simplest Audio Example 1")
-canvas = manifest.make_canvas(id="https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas", duration=1985.024)
+manifest = Manifest(id=f"{base_url}/manifest.json", label="Simplest Audio Example 1")
+canvas = manifest.make_canvas(id=f"{base_url}/canvas", duration=1985.024)
 anno_body = ResourceItem(id="https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4",
                          type="Sound",
                          format="audio/mp4",
                          duration=1985.024)
-anno_page = AnnotationPage(id="https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas/page")
-anno = Annotation(id="https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas/page/annotation",
+anno_page = AnnotationPage(id=f"{base_url}/canvas/page")
+anno = Annotation(id=f"{base_url}/canvas/page/annotation",
                   motivation="painting",
                   body=anno_body,
                   target=canvas.id)
@@ -17,3 +18,4 @@ anno_page.add_item(anno)
 canvas.add_item(anno_page)
 
 print(manifest.json(indent=2))
+

--- a/docs/recipes/scripts/0003-mvm-video-method1.py
+++ b/docs/recipes/scripts/0003-mvm-video-method1.py
@@ -1,14 +1,15 @@
 from iiif_prezi3 import Manifest, AnnotationPage, Annotation, ResourceItem, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0003-mvm-video"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0003-mvm-video/manifest.json", label="Video Example 3")
-canvas = manifest.make_canvas(id="https://iiif.io/api/cookbook/recipe/0003-mvm-video/canvas")
+manifest = Manifest(id=f"{base_url}/manifest.json", label="Video Example 3")
+canvas = manifest.make_canvas(id=f"{base_url}/canvas")
 anno_body = ResourceItem(id="https://fixtures.iiif.io/video/indiana/lunchroom_manners/high/lunchroom_manners_1024kb.mp4",
                          type="Video",
                          format="video/mp4")
-anno_page = AnnotationPage(id="https://iiif.io/api/cookbook/recipe/0003-mvm-video/canvas/page")
-anno = Annotation(id="https://iiif.io/api/cookbook/recipe/0003-mvm-video/canvas/page/annotation",
+anno_page = AnnotationPage(id=f"{base_url}/canvas/page")
+anno = Annotation(id=f"{base_url}/canvas/page/annotation",
                   motivation="painting",
                   body=anno_body,
                   target=canvas.id)

--- a/docs/recipes/scripts/0004-canvas-size-method1.py
+++ b/docs/recipes/scripts/0004-canvas-size-method1.py
@@ -1,14 +1,15 @@
 from iiif_prezi3 import Manifest, AnnotationPage, Annotation, ResourceItem, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0004-canvas-size"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0004-canvas-size/manifest.json", label="Still image from an opera performance at Indiana University")
-canvas = manifest.make_canvas(id="https://iiif.io/api/cookbook/recipe/0004-canvas-size/canvas/p1")
+manifest = Manifest(id=f"{base_url}/manifest.json", label="Still image from an opera performance at Indiana University")
+canvas = manifest.make_canvas(id=f"{base_url}/canvas/p1")
 anno_body = ResourceItem(id="https://fixtures.iiif.io/video/indiana/donizetti-elixir/act1-thumbnail.png",
                          type="Image",
                          format="image/png")
-anno_page = AnnotationPage(id="https://iiif.io/api/cookbook/recipe/0004-canvas-size/page/p1/1")
-anno = Annotation(id="https://iiif.io/api/cookbook/recipe/0004-canvas-size/annotation/p0001-image",
+anno_page = AnnotationPage(id=f"{base_url}/page/p1/1")
+anno = Annotation(id=f"{base_url}/annotation/p0001-image",
                   motivation="painting",
                   body=anno_body,
                   target=canvas.id)

--- a/docs/recipes/scripts/0005-image-service-method1.py
+++ b/docs/recipes/scripts/0005-image-service-method1.py
@@ -1,12 +1,13 @@
 from iiif_prezi3 import Manifest, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0005-image-service"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0005-image-service/manifest.json", label="Picture of Göttingen taken during the 2019 IIIF Conference")
+manifest = Manifest(id=f"{base_url}/manifest.json", label="Picture of Göttingen taken during the 2019 IIIF Conference")
 canvas = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
-                                        id="https://iiif.io/api/cookbook/recipe/0005-image-service/canvas/p1",
+                                        id=f"{base_url}/canvas/p1",
                                         label="Canvas with a single IIIF image",
-                                        anno_id="https://iiif.io/api/cookbook/recipe/0005-image-service/annotation/p0001-image",
-                                        anno_page_id="https://iiif.io/api/cookbook/recipe/0005-image-service/page/p1/1")
+                                        anno_id=f"{base_url}/annotation/p0001-image",
+                                        anno_page_id=f"{base_url}/page/p1/1")
 
 print(manifest.json(indent=2))

--- a/docs/recipes/scripts/0006-text-language-method1.py
+++ b/docs/recipes/scripts/0006-text-language-method1.py
@@ -1,6 +1,8 @@
 from iiif_prezi3 import Manifest, KeyValueString
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0006-text-language/manifest.json",
+base_url = "https://iiif.io/api/cookbook/recipe/0006-text-language"
+
+manifest = Manifest(id=f"{base_url}/manifest.json",
                     label={"en": ["Whistler's Mother"], "fr": ["La Mère de Whistler"]})
 manifest.metadata = [
     KeyValueString(label={"en": ["Creator"], "fr": ["Auteur"]}, value="Whistler, James Abbott McNeill"),
@@ -13,8 +15,8 @@ manifest.summary = {"en": ["Arrangement in Grey and Black No. 1, also called Por
 manifest.requiredStatement = KeyValueString(label={"en": ["Held By"], "fr": ["Détenu par"]}, value="Musée d'Orsay, Paris, France")
 
 canvas = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/329817fc8a251a01c393f517d8a17d87-Whistlers_Mother",
-                                        id="https://iiif.io/api/cookbook/recipe/0006-text-language/canvas/p1",
-                                        anno_id="https://iiif.io/api/cookbook/recipe/0006-text-language/annotation/p0001-image",
-                                        anno_page_id="https://iiif.io/api/cookbook/recipe/0006-text-language/page/p1/1")
+                                        id=f"{base_url}/canvas/p1",
+                                        anno_id=f"{base_url}/annotation/p0001-image",
+                                        anno_page_id=f"{base_url}/page/p1/1")
 
 print(manifest.json(indent=2))

--- a/docs/recipes/scripts/0007-string-formats-method1.py
+++ b/docs/recipes/scripts/0007-string-formats-method1.py
@@ -1,8 +1,9 @@
 from iiif_prezi3 import Manifest, KeyValueString, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0007-string-formats"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0007-string-formats/manifest.json",
+manifest = Manifest(id=f"{base_url}/manifest.json",
                     label="Picture of Göttingen taken during the 2019 IIIF Conference",
                     summary="<p>Picture taken by the <a href=\"https://github.com/glenrobson\">IIIF Technical Coordinator</a></p>",
                     rights="http://creativecommons.org/licenses/by-sa/3.0/",
@@ -10,8 +11,8 @@ manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0007-string-formats/
                                                      value="<span>Glen Robson, IIIF Technical Coordinator. <a href=\"https://creativecommons.org/licenses/by-sa/3.0\">CC BY-SA 3.0</a> <img src=\"https://licensebuttons.net/l/by-sa/3.0/88x31.png\"/></span>"),
                     metadata=[KeyValueString(label="Author", value={"none": ["<span><a href='https://github.com/glenrobson'>Glen Robson</a></span>"]})])
 canvas = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
-                                        id="https://iiif.io/api/cookbook/recipe/0007-string-formats/canvas/p1",
-                                        anno_id="https://iiif.io/api/cookbook/recipe/0007-string-formats/annotation/p0001-image",
-                                        anno_page_id="https://iiif.io/api/cookbook/recipe/0007-string-formats/page/p1/1")
+                                        id=f"{base_url}/canvas/p1",
+                                        anno_id=f"{base_url}/annotation/p0001-image",
+                                        anno_page_id=f"{base_url}/page/p1/1")
 
 print(manifest.json(indent=2))

--- a/docs/recipes/scripts/0008-rights-method1.py
+++ b/docs/recipes/scripts/0008-rights-method1.py
@@ -1,8 +1,9 @@
 from iiif_prezi3 import Manifest, KeyValueString, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0008-rights"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0008-rights/manifest.json",
+manifest = Manifest(id=f"{base_url}/manifest.json",
                     label="Picture of Göttingen taken during the 2019 IIIF Conference",
                     summary="<p>Picture taken by the <a href=\"https://github.com/glenrobson\">IIIF Technical Coordinator</a></p>",
                     rights="http://creativecommons.org/licenses/by-sa/3.0/",
@@ -11,8 +12,8 @@ manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0008-rights/manifest
                     )
 
 canvas = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
-                                        id="https://iiif.io/api/cookbook/recipe/0008-rights/canvas/p1",
-                                        anno_id="https://iiif.io/api/cookbook/recipe/0008-rights/annotation/p0001-image",
-                                        anno_page_id="https://iiif.io/api/cookbook/recipe/0008-rights/page/p1/1")
+                                        id=f"{base_url}/canvas/p1",
+                                        anno_id=f"{base_url}/annotation/p0001-image",
+                                        anno_page_id=f"{base_url}/page/p1/1")
 
 print(manifest.json(indent=2))

--- a/docs/recipes/scripts/0009-book-1-method1.py
+++ b/docs/recipes/scripts/0009-book-1-method1.py
@@ -1,38 +1,39 @@
 from iiif_prezi3 import Manifest, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0009-book-1"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0009-book-1/manifest.json",
+manifest = Manifest(id=f"{base_url}/manifest.json",
                     label="Simple Manifest - Book",
                     behavior=["paged"])
 canvas1 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f18",
-                                         id="https://iiif.io/api/cookbook/recipe/0009-book-1/canvas/p1",
+                                         id=f"{base_url}/canvas/p1",
                                          label="Blank page",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0009-book-1/annotation/p0001-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0009-book-1/page/p1/1")
+                                         anno_id=f"{base_url}/annotation/p0001-image",
+                                         anno_page_id=f"{base_url}/page/p1/1")
 
 canvas2 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f19",
-                                         id="https://iiif.io/api/cookbook/recipe/0009-book-1/canvas/p2",
+                                         id=f"{base_url}/canvas/p2",
                                          label="Frontispiece",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0009-book-1/annotation/p0002-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0009-book-1/page/p2/1")
+                                         anno_id=f"{base_url}/annotation/p0002-image",
+                                         anno_page_id=f"{base_url}/page/p2/1")
 
 canvas3 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f20",
-                                         id="https://iiif.io/api/cookbook/recipe/0009-book-1/canvas/p3",
+                                         id=f"{base_url}/canvas/p3",
                                          label="Title page",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0009-book-1/annotation/p0003-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0009-book-1/page/p3/1")
+                                         anno_id=f"{base_url}/annotation/p0003-image",
+                                         anno_page_id=f"{base_url}/page/p3/1")
 
 canvas4 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f21",
-                                         id="https://iiif.io/api/cookbook/recipe/0009-book-1/canvas/p4",
+                                         id=f"{base_url}/canvas/p4",
                                          label="Blank page",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0009-book-1/annotation/p0004-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0009-book-1/page/p4/1")
+                                         anno_id=f"{base_url}/annotation/p0004-image",
+                                         anno_page_id=f"{base_url}/page/p4/1")
 
 canvas5 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/59d09e6773341f28ea166e9f3c1e674f-gallica_ark_12148_bpt6k1526005v_f22",
-                                         id="https://iiif.io/api/cookbook/recipe/0009-book-1/canvas/p5",
+                                         id=f"{base_url}/canvas/p5",
                                          label="Bookplate",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0009-book-1/annotation/p0005-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0009-book-1/page/p5/1")
+                                         anno_id=f"{base_url}/annotation/p0005-image",
+                                         anno_page_id=f"{base_url}/page/p5/1")
 
 print(manifest.json(indent=2))

--- a/docs/recipes/scripts/0010-book-2-viewing-direction-method1-example1.py
+++ b/docs/recipes/scripts/0010-book-2-viewing-direction-method1-example1.py
@@ -1,40 +1,41 @@
 from iiif_prezi3 import Manifest, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/manifest-rtl.json",
+manifest = Manifest(id=f"{base_url}/manifest-rtl.json",
                     label="Book with Right-to-Left Viewing Direction",
                     summary="Playbill for \"Akiba gongen kaisen-banashi,\" \"Futatsu chōchō kuruwa nikki\" and \"Godairiki koi no fūjime\" performed at the Chikugo Theater in Osaka from the fifth month of Kaei 2 (May, 1849); main actors: Gadō Kataoka II, Ebizō Ichikawa VI, Kitō Sawamura II, Daigorō Mimasu IV and Karoku Nakamura I; on front cover: producer Mominosuke Ichikawa's crest.",
                     viewingDirection="right-to-left")
 
 canvas1 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_001",
-                                         id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/canvas/p1",
+                                         id=f"{base_url}/canvas/p1",
                                          label="front cover",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/annotation/p0001-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/page/p1/1")
+                                         anno_id=f"{base_url}/annotation/p0001-image",
+                                         anno_page_id=f"{base_url}/page/p1/1")
 
 canvas2 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_002",
-                                         id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/canvas/p2",
+                                         id=f"{base_url}/canvas/p2",
                                          label="pages 1–2",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/annotation/p0002-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/page/p2/1")
+                                         anno_id=f"{base_url}/annotation/p0002-image",
+                                         anno_page_id=f"{base_url}/page/p2/1")
 
 canvas3 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_003",
-                                         id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/canvas/p3",
+                                         id=f"{base_url}/canvas/p3",
                                          label="pages 3–4",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/annotation/p0003-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/page/p3/1")
+                                         anno_id=f"{base_url}/annotation/p0003-image",
+                                         anno_page_id=f"{base_url}/page/p3/1")
 
 canvas4 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_004",
-                                         id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/canvas/p4",
+                                         id=f"{base_url}/canvas/p4",
                                          label="pages 5–6",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/annotation/p0004-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/page/p4/1")
+                                         anno_id=f"{base_url}/annotation/p0004-image",
+                                         anno_page_id=f"{base_url}/page/p4/1")
 
 canvas5 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/4f92cceb12dd53b52433425ce44308c7-ucla_bib1987273_no001_rs_005",
-                                         id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/canvas/p5",
+                                         id=f"{base_url}/canvas/p5",
                                          label="back cover",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/annotation/p0005-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/page/p5/1")
+                                         anno_id=f"{base_url}/annotation/p0005-image",
+                                         anno_page_id=f"{base_url}/page/p5/1")
 
 print(manifest.json(indent=2))

--- a/docs/recipes/scripts/0010-book-2-viewing-direction-method1-example2.py
+++ b/docs/recipes/scripts/0010-book-2-viewing-direction-method1-example2.py
@@ -1,33 +1,34 @@
 from iiif_prezi3 import Manifest, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/manifest-ttb.json",
+manifest = Manifest(id=f"{base_url}/manifest-ttb.json",
                     label="Diary with Top-to-Bottom Viewing Direction",
                     summary="William Lewis Sachtleben was an American long-distance cyclist who rode across Asia from Istanbul to Peking in 1891 to 1892 with Thomas Gaskell Allen Jr., his classmate from Washington University. This was part of a longer journey that began the day after they had graduated from college, when they travelled to New York and on to Liverpool; in all they travelled 15,044 miles by bicycle, 'the longest continuous land journey ever made around the world' as reported in their book <cite>Across Asia on a bicycle</cite> (1895). Sachtleben documented his travels with photographs and diaries, the latter of which he numbered sequentially. The diary of notebook 'No. 10' covers a portion of their journey through the Armenian area of Turkey from April 12 to May 9 (there is a 2-page reading list at the end). During this time they rode from Ankara (Angora in the diary) to Sivas, where they stayed for ten days while Allen had a bout of typhoid fever, and the first half of a ten-day excursion to Merzifon (Mersovan in the diary), taken by Sachtleben to give Allen additional time to recover.",
                     viewingDirection="top-to-bottom")
 canvas1 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/9ee11092dfd2782634f5e8e2c87c16d5-uclamss_1841_diary_07_02",
-                                         id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/canvas/v1",
+                                         id=f"{base_url}/canvas/v1",
                                          label="image 1",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/annotation/v0001-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/page/v1/1")
+                                         anno_id=f"{base_url}/annotation/v0001-image",
+                                         anno_page_id=f"{base_url}/page/v1/1")
 
 canvas2 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/9ee11092dfd2782634f5e8e2c87c16d5-uclamss_1841_diary_07_03",
-                                         id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/canvas/v2",
+                                         id=f"{base_url}/canvas/v2",
                                          label="image 2",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/annotation/v0002-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/page/v2/1")
+                                         anno_id=f"{base_url}/annotation/v0002-image",
+                                         anno_page_id=f"{base_url}/page/v2/1")
 
 canvas3 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/9ee11092dfd2782634f5e8e2c87c16d5-uclamss_1841_diary_07_04",
-                                         id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/canvas/v3",
+                                         id=f"{base_url}/canvas/v3",
                                          label="image 3",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/annotation/v0003-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/page/v3/1")
+                                         anno_id=f"{base_url}/annotation/v0003-image",
+                                         anno_page_id=f"{base_url}/page/v3/1")
 
 canvas4 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/9ee11092dfd2782634f5e8e2c87c16d5-uclamss_1841_diary_07_05",
-                                         id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/canvas/v4",
+                                         id=f"{base_url}/canvas/v4",
                                          label="image 4",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/annotation/v0004-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0010-book-2-viewing-direction/page/v4/1")
+                                         anno_id=f"{base_url}/annotation/v0004-image",
+                                         anno_page_id=f"{base_url}/page/v4/1")
 
 print(manifest.json(indent=2))

--- a/docs/recipes/scripts/0011-book-3-behavior-method1-usecase1.py
+++ b/docs/recipes/scripts/0011-book-3-behavior-method1-usecase1.py
@@ -1,31 +1,33 @@
 from iiif_prezi3 import Manifest, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/manifest-continuous.json",
+base_url = "https://iiif.io/api/cookbook/recipe/0011-book-3-behavior"
+
+manifest = Manifest(id=f"{base_url}/manifest-continuous.json",
                     label={"gez": ["Ms. 21 Māzemurā Dāwit, Asmat [መዝሙረ ዳዊት]"]},
                     behavior=["continuous"])
 canvas1 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/8c169124171e6b2253b698a22a938f07-21198-zz001hbmd9_1300412_master",
-                                         id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/canvas/s1",
+                                         id=f"{base_url}/canvas/s1",
                                          label="Section 1 [Recto]",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/annotation/s0001-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/page/s1/1")
+                                         anno_id=f"{base_url}/annotation/s0001-image",
+                                         anno_page_id=f"{base_url}/page/s1/1")
 
 canvas2 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/8c169124171e6b2253b698a22a938f07-21198-zz001hbmft_1300418_master",
-                                         id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/canvas/s2",
+                                         id=f"{base_url}/canvas/s2",
                                          label="Section 2 [Recto]",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/annotation/s0002-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/page/s2/1")
+                                         anno_id=f"{base_url}/annotation/s0002-image",
+                                         anno_page_id=f"{base_url}/page/s2/1")
 
 canvas3 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/8c169124171e6b2253b698a22a938f07-21198-zz001hbmgb_1300426_master",
-                                         id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/canvas/s3",
+                                         id=f"{base_url}/canvas/s3",
                                          label="Section 3 [Recto]",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/annotation/s0003-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/page/s3/1")
+                                         anno_id=f"{base_url}/annotation/s0003-image",
+                                         anno_page_id=f"{base_url}/page/s3/1")
 
 canvas4 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/8c169124171e6b2253b698a22a938f07-21198-zz001hbmhv_1300436_master",
-                                         id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/canvas/s4",
+                                         id=f"{base_url}/canvas/s4",
                                          label="Section 4 [Recto]",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/annotation/s0004-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/page/s4/1")
+                                         anno_id=f"{base_url}/annotation/s0004-image",
+                                         anno_page_id=f"{base_url}/page/s4/1")
 
 print(manifest.json(indent=2))

--- a/docs/recipes/scripts/0011-book-3-behavior-method1-usecase2.py
+++ b/docs/recipes/scripts/0011-book-3-behavior-method1-usecase2.py
@@ -1,32 +1,34 @@
 from iiif_prezi3 import Manifest, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/manifest-individuals.json",
+base_url = "https://iiif.io/api/cookbook/recipe/0011-book-3-behavior"
+
+manifest = Manifest(id=f"{base_url}/manifest-individuals.json",
                     label={"ca": ["[Conoximent de las orines] Ihesus, Ihesus. En nom de Deu et dela beneyeta sa mare e de tots los angels i archangels e de tots los sants e santes de paradis yo micer Johannes comense aquest libre de reseptes en l’ayn Mi 466."]},
                     behavior=["individuals"])
 
 canvas1 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/85a96c630f077e6ac6cb984f1b752bbf-0-21198-zz00022840-1-master",
-                                         id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/canvas/v1",
+                                         id=f"{base_url}/canvas/v1",
                                          label="inside cover; 1r",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/annotation/v0001-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/page/v1/1")
+                                         anno_id=f"{base_url}/annotation/v0001-image",
+                                         anno_page_id=f"{base_url}/page/v1/1")
 
 canvas2 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/85a96c630f077e6ac6cb984f1b752bbf-1-21198-zz00022882-1-master",
-                                         id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/canvas/v2",
+                                         id=f"{base_url}/canvas/v2",
                                          label="2v, 3r",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/annotation/v0002-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/page/v2/1")
+                                         anno_id=f"{base_url}/annotation/v0002-image",
+                                         anno_page_id=f"{base_url}/page/v2/1")
 
 canvas3 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/85a96c630f077e6ac6cb984f1b752bbf-2-21198-zz000228b3-1-master",
-                                         id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/canvas/v3",
+                                         id=f"{base_url}/canvas/v3",
                                          label="3v, 4r",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/annotation/v0003-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/page/v3/1")
+                                         anno_id=f"{base_url}/annotation/v0003-image",
+                                         anno_page_id=f"{base_url}/page/v3/1")
 
 canvas4 = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/85a96c630f077e6ac6cb984f1b752bbf-3-21198-zz000228d4-1-master",
-                                         id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/canvas/v4",
+                                         id=f"{base_url}/canvas/v4",
                                          label="4v, 5r",
-                                         anno_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/annotation/v0004-image",
-                                         anno_page_id="https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/page/v4/1")
+                                         anno_id=f"{base_url}/annotation/v0004-image",
+                                         anno_page_id=f"{base_url}/page/v4/1")
 
 print(manifest.json(indent=2))

--- a/docs/recipes/scripts/0015-start-method1.py
+++ b/docs/recipes/scripts/0015-start-method1.py
@@ -1,20 +1,22 @@
 from iiif_prezi3 import Manifest, KeyValueString, ResourceItem, AnnotationPage, Annotation, SpecificResource, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0015-start/manifest.json",
+base_url = "https://iiif.io/api/cookbook/recipe/0015-start"
+
+manifest = Manifest(id=f"{base_url}/manifest.json",
                     label="Video of a 30-minute digital clock",
                     rights="http://creativecommons.org/licenses/by/3.0/",
                     requiredStatement=KeyValueString(label="Attribution",
                                                      value="<span>The video was created by <a href='https://www.youtube.com/watch?v=Lsq0FiXjGHg'>DrLex1</a> and was released using a <a href='https://creativecommons.org/licenses/by/3.0/'>Creative Commons Attribution license</a></span>")
                     )
 
-canvas = manifest.make_canvas(id="https://iiif.io/api/cookbook/recipe/0015-start/canvas/segment1", duration=1801.055)
+canvas = manifest.make_canvas(id=f"{base_url}/canvas/segment1", duration=1801.055)
 anno_body = ResourceItem(id="https://fixtures.iiif.io/video/indiana/30-minute-clock/medium/30-minute-clock.mp4",
                          type="Video",
                          format="video/mp4",
                          duration=1801.055)
-anno_page = AnnotationPage(id="https://iiif.io/api/cookbook/recipe/0015-start/annotation/segment1/page")
-anno = Annotation(id="https://iiif.io/api/cookbook/recipe/0015-start/annotation/segment1-video",
+anno_page = AnnotationPage(id=f"{base_url}/annotation/segment1/page")
+anno = Annotation(id=f"{base_url}/annotation/segment1-video",
                   motivation="painting",
                   body=anno_body,
                   target=canvas.id)
@@ -22,7 +24,7 @@ anno = Annotation(id="https://iiif.io/api/cookbook/recipe/0015-start/annotation/
 anno_page.add_item(anno)
 canvas.add_item(anno_page)
 
-manifest.start = SpecificResource(id="https://iiif.io/api/cookbook/recipe/0015-start/canvas-start/segment1",
+manifest.start = SpecificResource(id=f"{base_url}/canvas-start/segment1",
                                   source=canvas.id,
                                   selector={"type": "PointSelector", "t": 120.5})
 

--- a/docs/recipes/scripts/0017-transcription-av-method1.py
+++ b/docs/recipes/scripts/0017-transcription-av-method1.py
@@ -1,15 +1,17 @@
 from iiif_prezi3 import Manifest, ExternalItem, ResourceItem, AnnotationPage, Annotation, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0017-transcription-av/manifest.json",
+base_url = "https://iiif.io/api/cookbook/recipe/0017-transcription-av"
+
+manifest = Manifest(id=f"{base_url}/manifest.json",
                     label="Volleyball for Boys")
 
-canvas = manifest.make_canvas(id="https://iiif.io/api/cookbook/recipe/0017-transcription-av/canvas")
+canvas = manifest.make_canvas(id=f"{base_url}/canvas")
 anno_body = ResourceItem(id="https://fixtures.iiif.io/video/indiana/volleyball/high/volleyball-for-boys.mp4",
                          type="Video",
                          format="video/mp4")
-anno_page = AnnotationPage(id="https://iiif.io/api/cookbook/recipe/0017-transcription-av/canvas/page")
-anno = Annotation(id="https://iiif.io/api/cookbook/recipe/0017-transcription-av/canvas/page/annotation",
+anno_page = AnnotationPage(id=f"{base_url}/canvas/page")
+anno = Annotation(id=f"{base_url}/canvas/page/annotation",
                   motivation="painting",
                   body=anno_body,
                   target=canvas.id)

--- a/docs/recipes/scripts/0019-html-in-annotations-method1.py
+++ b/docs/recipes/scripts/0019-html-in-annotations-method1.py
@@ -1,19 +1,21 @@
 from iiif_prezi3 import Manifest
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0019-html-in-annotations/manifest.json",
+base_url = "https://iiif.io/api/cookbook/recipe/0019-html-in-annotations"
+
+manifest = Manifest(id=f"{base_url}/manifest.json",
                     label={"en": ["Picture of Göttingen taken during the 2019 IIIF Conference"]})
 canvas = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
-                                        id="https://iiif.io/api/cookbook/recipe/0019-html-in-annotations/canvas-1",
-                                        anno_id="https://iiif.io/api/cookbook/recipe/0019-html-in-annotations/canvas-1/annopage-1/anno-1",
-                                        anno_page_id="https://iiif.io/api/cookbook/recipe/0019-html-in-annotations/canvas-1/annopage-1")
+                                        id=f"{base_url}/canvas-1",
+                                        anno_id=f"{base_url}/canvas-1/annopage-1/anno-1",
+                                        anno_page_id=f"{base_url}/canvas-1/annopage-1")
 
-anno = canvas.make_annotation(id="https://iiif.io/api/cookbook/recipe/0019-html-in-annotations/canvas-1/annopage-2/anno-1",
+anno = canvas.make_annotation(id=f"{base_url}/canvas-1/annopage-2/anno-1",
                               motivation="commenting",
                               body={"type": "TextualBody",
                                     "language": "de",
                                     "format": "text/html",
                                     "value": "<p>Göttinger Marktplatz mit <a href='https://de.wikipedia.org/wiki/G%C3%A4nseliesel-Brunnen_(G%C3%B6ttingen)'>Gänseliesel Brunnen <img src='https://en.wikipedia.org/static/images/project-logos/enwiki.png' alt='Wikipedia logo'></a></p>"},
                               target=canvas.id,
-                              anno_page_id="https://iiif.io/api/cookbook/recipe/0019-html-in-annotations/canvas-1/annopage-2")
+                              anno_page_id=f"{base_url}/canvas-1/annopage-2")
 
 print(manifest.json(indent=2))

--- a/docs/recipes/scripts/0021-tagging-method1.py
+++ b/docs/recipes/scripts/0021-tagging-method1.py
@@ -1,19 +1,21 @@
 from iiif_prezi3 import Manifest
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0021-tagging/manifest.json",
+base_url = "https://iiif.io/api/cookbook/recipe/0021-tagging"
+
+manifest = Manifest(id=f"{base_url}/manifest.json",
                     label={"en": ["Picture of Göttingen taken during the 2019 IIIF Conference"]})
 canvas = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
-                                        id="https://iiif.io/api/cookbook/recipe/0021-tagging/canvas/p1",
-                                        anno_id="https://iiif.io/api/cookbook/recipe/0021-tagging/annotation/p0001-image",
-                                        anno_page_id="https://iiif.io/api/cookbook/recipe/0021-tagging/page/p1/1")
+                                        id=f"{base_url}/canvas/p1",
+                                        anno_id=f"{base_url}/annotation/p0001-image",
+                                        anno_page_id=f"{base_url}/page/p1/1")
 
-anno = canvas.make_annotation(id="https://iiif.io/api/cookbook/recipe/0021-tagging/annotation/p0002-tag",
+anno = canvas.make_annotation(id=f"{base_url}/annotation/p0002-tag",
                               motivation="tagging",
                               body={"type": "TextualBody",
                                     "language": "de",
                                     "format": "text/plain",
                                     "value": "Gänseliesel-Brunnen"},
                               target=canvas.id + "#xywh=265,661,1260,1239",
-                              anno_page_id="https://iiif.io/api/cookbook/recipe/0021-tagging/page/p2/1")
+                              anno_page_id=f"{base_url}/page/p2/1")
 
 print(manifest.json(indent=2))

--- a/docs/recipes/scripts/0118-multivalue-method1.py
+++ b/docs/recipes/scripts/0118-multivalue-method1.py
@@ -1,5 +1,7 @@
 from iiif_prezi3 import Manifest, KeyValueString
 
+base_url = "https://iiif.io/api/cookbook/recipe/0118-multivalue"
+
 manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0118_multivalue/manifest.json",
                     label={"fr": ["Arrangement en gris et noir no 1"]})
 manifest.metadata = [

--- a/docs/recipes/scripts/0230-navdate-method1-example1.py
+++ b/docs/recipes/scripts/0230-navdate-method1-example1.py
@@ -2,16 +2,17 @@ from iiif_prezi3 import Manifest, config
 from datetime import datetime, timezone
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0230-navdate"
 
 # n.b: You MUST set `tzinfo` as the Prezi3 Specification requires a timezone, and the default `datetime` does not have one.
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_2-manifest.json",
+manifest = Manifest(id=f"{base_url}/navdate_map_2-manifest.json",
                     label="1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide",
                     navDate=datetime(1986, 1, 1, tzinfo=timezone.utc))
 canvas = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-87691274-1986",
-                                        id="https://iiif.io/api/cookbook/recipe/0230-navdate/canvas/p1",
+                                        id=f"{base_url}/canvas/p1",
                                         label="1986 Map, recto and verso, with a date of publication",
-                                        anno_id="https://iiif.io/api/cookbook/recipe/0230-navdate/annotation/p0001-image",
-                                        anno_page_id="https://iiif.io/api/cookbook/recipe/0230-navdate/page/p1/1")
+                                        anno_id=f"{base_url}/annotation/p0001-image",
+                                        anno_page_id=f"{base_url}/page/p1/1")
 
 # This is a workaround for an inconsistency in the Cookbook JSON - see https://github.com/IIIF/cookbook-recipes/issues/376
 canvas.items[0].items[0].body.service[0].id = "https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-87691274-1986/"

--- a/docs/recipes/scripts/0230-navdate-method1-example2.py
+++ b/docs/recipes/scripts/0230-navdate-method1-example2.py
@@ -2,16 +2,17 @@ from iiif_prezi3 import Manifest, config
 from datetime import datetime, timezone
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0230-navdate"
 
 # n.b: You MUST set `tzinfo` as the Prezi3 Specification requires a timezone, and the default `datetime` does not have one.
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_1-manifest.json",
+manifest = Manifest(id=f"{base_url}/navdate_map_1-manifest.json",
                     label="1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide",
                     navDate=datetime(1987, 1, 1, tzinfo=timezone.utc))
 canvas = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-88695674",
-                                        id="https://iiif.io/api/cookbook/recipe/0230-navdate/canvas/p1",
+                                        id=f"{base_url}/canvas/p1",
                                         label="1987 Map, recto and verso, with a date of publication",
-                                        anno_id="https://iiif.io/api/cookbook/recipe/0230-navdate/annotation/p0001-image",
-                                        anno_page_id="https://iiif.io/api/cookbook/recipe/0230-navdate/page/p1/1")
+                                        anno_id=f"{base_url}/annotation/p0001-image",
+                                        anno_page_id=f"{base_url}/page/p1/1")
 
 # This is a workaround for an inconsistency in the Cookbook JSON - see https://github.com/IIIF/cookbook-recipes/issues/376
 canvas.items[0].items[0].body.service[0].id = "https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-88695674/"

--- a/docs/recipes/scripts/0230-navdate-method1-example3.py
+++ b/docs/recipes/scripts/0230-navdate-method1-example3.py
@@ -2,27 +2,28 @@ from iiif_prezi3 import Collection, Manifest, ResourceItem, config
 from datetime import datetime, timezone
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0230-navdate"
 
 # n.b: You MUST set `tzinfo` as the Prezi3 Specification requires a timezone, and the default `datetime` does not have one.
-manifest1986 = Manifest(id="https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_2-manifest.json",
+manifest1986 = Manifest(id=f"{base_url}/navdate_map_2-manifest.json",
                         label="1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide",
                         navDate=datetime(1986, 1, 1, tzinfo=timezone.utc))
 canvas1986 = manifest1986.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-87691274-1986",
-                                                id="https://iiif.io/api/cookbook/recipe/0230-navdate/canvas/p1",
+                                                id=f"{base_url}/canvas/p1",
                                                 label="1986 Map, recto and verso, with a date of publication",
-                                                anno_id="https://iiif.io/api/cookbook/recipe/0230-navdate/annotation/p0001-image",
-                                                anno_page_id="https://iiif.io/api/cookbook/recipe/0230-navdate/page/p1/1")
+                                                anno_id=f"{base_url}/annotation/p0001-image",
+                                                anno_page_id=f"{base_url}/page/p1/1")
 
-manifest1987 = Manifest(id="https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_1-manifest.json",
+manifest1987 = Manifest(id=f"{base_url}/navdate_map_1-manifest.json",
                         label="1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide",
                         navDate=datetime(1987, 1, 1, tzinfo=timezone.utc))
 canvas1987 = manifest1987.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-88695674",
-                                                id="https://iiif.io/api/cookbook/recipe/0230-navdate/canvas/p1",
+                                                id=f"{base_url}/canvas/p1",
                                                 label="1987 Map, recto and verso, with a date of publication",
-                                                anno_id="https://iiif.io/api/cookbook/recipe/0230-navdate/annotation/p0001-image",
-                                                anno_page_id="https://iiif.io/api/cookbook/recipe/0230-navdate/page/p1/1")
+                                                anno_id=f"{base_url}/annotation/p0001-image",
+                                                anno_page_id=f"{base_url}/page/p1/1")
 
-collection = Collection(id="https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json",
+collection = Collection(id=f"{base_url}/navdate-collection.json",
                         label="Chesapeake and Ohio Canal map and guide pamphlets")
 thumbnail = ResourceItem(id="https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-88695674/full/max/0/default.jpg",
                          type="Image",

--- a/docs/recipes/scripts/0230-navdate-method2-example1.py
+++ b/docs/recipes/scripts/0230-navdate-method2-example1.py
@@ -1,16 +1,17 @@
 from iiif_prezi3 import Manifest, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0230-navdate"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_2-manifest.json",
+manifest = Manifest(id=f"{base_url}/navdate_map_2-manifest.json",
                     label="1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide",
                     navDate="1986-01-01T00:00:00Z")
 
 canvas = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-87691274-1986",
-                                        id="https://iiif.io/api/cookbook/recipe/0230-navdate/canvas/p1",
+                                        id=f"{base_url}/canvas/p1",
                                         label="1986 Map, recto and verso, with a date of publication",
-                                        anno_id="https://iiif.io/api/cookbook/recipe/0230-navdate/annotation/p0001-image",
-                                        anno_page_id="https://iiif.io/api/cookbook/recipe/0230-navdate/page/p1/1")
+                                        anno_id=f"{base_url}/annotation/p0001-image",
+                                        anno_page_id=f"{base_url}/page/p1/1")
 
 # This is a workaround for an inconsistency in the Cookbook JSON - see https://github.com/IIIF/cookbook-recipes/issues/376
 canvas.items[0].items[0].body.service[0].id = "https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-87691274-1986/"

--- a/docs/recipes/scripts/0230-navdate-method2-example2.py
+++ b/docs/recipes/scripts/0230-navdate-method2-example2.py
@@ -1,15 +1,16 @@
 from iiif_prezi3 import Manifest, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0230-navdate"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_1-manifest.json",
+manifest = Manifest(id=f"{base_url}/navdate_map_1-manifest.json",
                     label="1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide",
                     navDate="1987-01-01T00:00:00Z")
 canvas = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-88695674",
-                                        id="https://iiif.io/api/cookbook/recipe/0230-navdate/canvas/p1",
+                                        id=f"{base_url}/canvas/p1",
                                         label="1987 Map, recto and verso, with a date of publication",
-                                        anno_id="https://iiif.io/api/cookbook/recipe/0230-navdate/annotation/p0001-image",
-                                        anno_page_id="https://iiif.io/api/cookbook/recipe/0230-navdate/page/p1/1")
+                                        anno_id=f"{base_url}/annotation/p0001-image",
+                                        anno_page_id=f"{base_url}/page/p1/1")
 
 # This is a workaround for an inconsistency in the Cookbook JSON - see https://github.com/IIIF/cookbook-recipes/issues/376
 canvas.items[0].items[0].body.service[0].id = "https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-88695674/"

--- a/docs/recipes/scripts/0230-navdate-method2-example3.py
+++ b/docs/recipes/scripts/0230-navdate-method2-example3.py
@@ -1,8 +1,9 @@
 from iiif_prezi3 import Collection, ManifestRef, ResourceItem, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0230-navdate"
 
-collection = Collection(id="https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json",
+collection = Collection(id=f"{base_url}/navdate-collection.json",
                         label="Chesapeake and Ohio Canal map and guide pamphlets")
 thumbnail = ResourceItem(id="https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-88695674/full/max/0/default.jpg",
                          type="Image",
@@ -14,12 +15,12 @@ thumbnail.make_service(id="https://iiif.io/api/image/3.0/example/reference/43153
                        profile="level1")
 collection.thumbnail = [thumbnail]
 
-manifest1986 = ManifestRef(id="https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_2-manifest.json",
+manifest1986 = ManifestRef(id=f"{base_url}/navdate_map_2-manifest.json",
                            type="Manifest",
                            label="1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide",
                            navDate="1986-01-01T00:00:00+00:00")
 
-manifest1987 = ManifestRef(id="https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_1-manifest.json",
+manifest1987 = ManifestRef(id=f"{base_url}/navdate_map_1-manifest.json",
                            type="Manifest",
                            label="1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide",
                            navDate="1987-01-01T00:00:00+00:00")

--- a/docs/recipes/scripts/0261-non-rectangular-commenting-method1.py
+++ b/docs/recipes/scripts/0261-non-rectangular-commenting-method1.py
@@ -1,13 +1,14 @@
 from iiif_prezi3 import Manifest, config
 
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+base_url = "https://iiif.io/api/cookbook/recipe/0261-non-rectangular-commenting"
 
-manifest = Manifest(id="https://iiif.io/api/cookbook/recipe/0261-non-rectangular-commenting/manifest.json", label="Picture of Göttingen taken during the 2019 IIIF Conference")
+manifest = Manifest(id=f"{base_url}/manifest.json", label="Picture of Göttingen taken during the 2019 IIIF Conference")
 canvas = manifest.make_canvas_from_iiif(url="https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
-                                        id="https://iiif.io/api/cookbook/recipe/0261-non-rectangular-commenting/canvas/p1",
-                                        anno_id="https://iiif.io/api/cookbook/recipe/0261-non-rectangular-commenting/annotation/p0001-image",
-                                        anno_page_id="https://iiif.io/api/cookbook/recipe/0261-non-rectangular-commenting/page/p1/1")
-anno = canvas.make_annotation(id="https://iiif.io/api/cookbook/recipe/0261-non-rectangular-commenting/annotation/p0002-svg",
+                                        id=f"{base_url}/canvas/p1",
+                                        anno_id=f"{base_url}/annotation/p0001-image",
+                                        anno_page_id=f"{base_url}/page/p1/1")
+anno = canvas.make_annotation(id=f"{base_url}/annotation/p0002-svg",
                               motivation="tagging",
                               body={"type": "TextualBody",
                                     "language": "de",
@@ -19,6 +20,6 @@ anno = canvas.make_annotation(id="https://iiif.io/api/cookbook/recipe/0261-non-r
                                                    "value": "<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'><g><path d='M270.000000,1900.000000 L1530.000000,1900.000000 L1530.000000,1610.000000 L1315.000000,1300.000000 L1200.000000,986.000000 L904.000000,661.000000 L600.000000,986.000000 L500.000000,1300.000000 L270,1630 L270.000000,1900.000000' /></g></svg>"
                                                    }
                                       },
-                              anno_page_id="https://iiif.io/api/cookbook/recipe/0261-non-rectangular-commenting/page/p2/1")
+                              anno_page_id=f"{base_url}/page/p2/1")
 
 print(manifest.json(indent=2))


### PR DESCRIPTION
Picking up on an idea I used during my [dogfooding of the "Introduction to `iiif-prezi3`" lightning talk](https://digitaldogsbody.net/iiif/prezi3): due to the structure of the recipes, there are a lot of `id` fields that have a common start, so this PR adds a `base_url` variable and uses it in the various bits of manifest data, meaning that the resulting code looks a bit less cluttered (IMO)