### PR TITLE
Add Recipe 0014 and add add_item() to AccompanyingCanvas

### DIFF
--- a/docs/recipes/0014-accompanyingcanvas.md
+++ b/docs/recipes/0014-accompanyingcanvas.md
@@ -6,5 +6,5 @@
 
 ### Method 1 - Use AccompanyingCanvas and add_item() helper
 ```python
---8<-- "docs/recipes/scripts/0014-accompanyingcanvas.py"
+--8<-- "docs/recipes/scripts/0014-accompanyingcanvas-method1.py"
 ```

--- a/docs/recipes/0014-accompanyingcanvas.md
+++ b/docs/recipes/0014-accompanyingcanvas.md
@@ -1,0 +1,10 @@
+# "Audio Presentation with Accompanying Image"
+|              | **Cookbook URLs** |
+|--------------|-------------------|
+| **Recipe:**  | [https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/](https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/) |
+| **JSON-LD:** | [https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/manifest.json](https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/manifest.json) |
+
+### Method 1 - Use AccompanyingCanvas and add_item() helper
+```python
+--8<-- "docs/recipes/scripts/0014-accompanyingcanvas.py"
+```

--- a/docs/recipes/scripts/0014-accompanyingcanvas-method1.py
+++ b/docs/recipes/scripts/0014-accompanyingcanvas-method1.py
@@ -37,8 +37,6 @@ accompanying_canvas.add_item(ac_anno_page)
 canvas = manifest.make_canvas(
     id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/p1",
     label="Gustav Mahler, Symphony No. 3, CD 1",
-    height=998,
-    width=772,
     duration=1985.024,
     accompanyingCanvas=accompanying_canvas
 )

--- a/docs/recipes/scripts/0014-accompanyingcanvas-method1.py
+++ b/docs/recipes/scripts/0014-accompanyingcanvas-method1.py
@@ -1,14 +1,16 @@
 from iiif_prezi3 import Manifest, ResourceItem, AnnotationPage, Annotation, config, AccompanyingCanvas
 
+base_url = "https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas"
+
 config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
 accompanying_canvas = AccompanyingCanvas(
-    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying",
+    id=f"{base_url}/canvas/accompanying",
     label="First page of score for Gustav Mahler, Symphony No. 3",
     height=998,
     width=772,
 )
 manifest = Manifest(
-    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/manifest.json",
+    id=f"{base_url}/manifest.json",
     label="Partial audio recording of Gustav Mahler's _Symphony No. 3_",
 )
 ac_anno_body = ResourceItem(
@@ -24,18 +26,18 @@ ac_anno_body.make_service(
     profile="level1"
 )
 ac_anno_page = AnnotationPage(
-    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/page"
+    id=f"{base_url}/canvas/accompanying/annotation/page"
 )
 ac_anno = Annotation(
-    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/image",
+    id=f"{base_url}/canvas/accompanying/annotation/image",
     motivation="painting",
     body=ac_anno_body,
-    target="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying"
+    target=f"{base_url}/canvas/accompanying"
 )
 ac_anno_page.add_item(ac_anno)
 accompanying_canvas.add_item(ac_anno_page)
 canvas = manifest.make_canvas(
-    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/p1",
+    id=f"{base_url}/canvas/p1",
     label="Gustav Mahler, Symphony No. 3, CD 1",
     duration=1985.024,
     accompanyingCanvas=accompanying_canvas
@@ -47,10 +49,10 @@ anno_body = ResourceItem(
     duration=1985.024,
 )
 anno_page = AnnotationPage(
-    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/p1"
+    id=f"{base_url}/canvas/page/p1"
 )
 anno = Annotation(
-    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/annotation/segment1-audio",
+    id=f"{base_url}/canvas/page/annotation/segment1-audio",
     motivation="painting",
     body=anno_body,
     target=canvas.id

--- a/docs/recipes/scripts/0014-accompanyingcanvas-method1.py
+++ b/docs/recipes/scripts/0014-accompanyingcanvas-method1.py
@@ -1,0 +1,62 @@
+from iiif_prezi3 import Manifest, ResourceItem, AnnotationPage, Annotation, config, AccompanyingCanvas
+
+config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+accompanying_canvas = AccompanyingCanvas(
+    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying",
+    label="First page of score for Gustav Mahler, Symphony No. 3",
+    height=998,
+    width=772,
+)
+manifest = Manifest(
+    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/manifest.json",
+    label="Partial audio recording of Gustav Mahler's _Symphony No. 3_",
+)
+ac_anno_body = ResourceItem(
+    id="https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0/full/,998/0/default.jpg",
+    type="Image",
+    format="image/jpeg",
+    height=998,
+    width=772,
+)
+ac_anno_body.make_service(
+    id="https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0",
+    type="ImageService3",
+    profile="level1"
+)
+ac_anno_page = AnnotationPage(
+    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/page"
+)
+ac_anno = Annotation(
+    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/image",
+    motivation="painting",
+    body=ac_anno_body,
+    target="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying"
+)
+ac_anno_page.add_item(ac_anno)
+accompanying_canvas.add_item(ac_anno_page)
+canvas = manifest.make_canvas(
+    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/p1",
+    label="Gustav Mahler, Symphony No. 3, CD 1",
+    height=998,
+    width=772,
+    duration=1985.024,
+    accompanyingCanvas=accompanying_canvas
+)
+anno_body = ResourceItem(
+    id="https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4",
+    type="Sound",
+    format="video/mp4",
+    duration=1985.024,
+)
+anno_page = AnnotationPage(
+    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/p1"
+)
+anno = Annotation(
+    id="https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/annotation/segment1-audio",
+    motivation="painting",
+    body=anno_body,
+    target=canvas.id
+)
+anno_page.add_item(anno)
+canvas.add_item(anno_page)
+print(manifest.json(indent=2))

--- a/iiif_prezi3/helpers/add_item.py
+++ b/iiif_prezi3/helpers/add_item.py
@@ -1,6 +1,6 @@
 from ..loader import monkeypatch_schema
-from ..skeleton import (AnnotationPage, Canvas, Collection, Manifest, Range,
-                        Reference)
+from ..skeleton import (AccompanyingCanvas, AnnotationPage, Canvas, Collection,
+                        Manifest, Range, Reference)
 
 
 class AddItem:
@@ -10,6 +10,7 @@ class AddItem:
         Args:
             item (Union[Collection, Manifest, Canvas, AnnotationPage, Annotation, Range, Reference, SpecificResource, Item])): The object to be added
         """
+        print(item)
         if not self.items:
             self.items = []
 
@@ -37,5 +38,5 @@ class AddItemByReference:
         self.items = self.items  # Force Pydantic to validate?
 
 
-monkeypatch_schema([Collection, Manifest, Canvas, Range, AnnotationPage, Reference], AddItem)
-monkeypatch_schema([Collection, Range, Canvas, AnnotationPage], AddItemByReference)
+monkeypatch_schema([Collection, Manifest, Canvas, Range, AnnotationPage, Reference, AccompanyingCanvas], AddItem)
+monkeypatch_schema([Collection, Range, Canvas, AnnotationPage, AccompanyingCanvas], AddItemByReference)

--- a/iiif_prezi3/helpers/add_item.py
+++ b/iiif_prezi3/helpers/add_item.py
@@ -10,7 +10,6 @@ class AddItem:
         Args:
             item (Union[Collection, Manifest, Canvas, AnnotationPage, Annotation, Range, Reference, SpecificResource, Item])): The object to be added
         """
-        print(item)
         if not self.items:
             self.items = []
 

--- a/tests/test_add_item.py
+++ b/tests/test_add_item.py
@@ -2,8 +2,9 @@ import unittest
 
 from pydantic import ValidationError
 
-from iiif_prezi3 import (Annotation, AnnotationPage, Canvas, Collection,
-                         CollectionRef, Manifest, ManifestRef, ResourceItem)
+from iiif_prezi3 import (AccompanyingCanvas, Annotation, AnnotationPage,
+                         Canvas, Collection, CollectionRef, Manifest,
+                         ManifestRef, ResourceItem)
 
 
 class AddItemTests(unittest.TestCase):
@@ -16,6 +17,7 @@ class AddItemTests(unittest.TestCase):
         self.ca2 = Canvas(label="second canvas", type="Canvas")
         self.ap = AnnotationPage()
         self.a = Annotation(target=self.c.id)
+        self.ac = AccompanyingCanvas()
 
     def test_add_item(self):
         """Test that a Canvas added to an empty Manifest creates and populates items."""
@@ -74,3 +76,8 @@ class AddItemTests(unittest.TestCase):
         """Test that adding an invalid reference type fails."""
         with self.assertRaises(ValidationError):
             self.c2.add_item_by_reference(self.ca)
+
+    def test_add_item_to_accompanying_canvas(self):
+        """Test that an item can be added to an items list in Accompanying Canvas."""
+        self.ac.add_item(self.ap)
+        self.assertIsInstance(self.ac.items[0], AnnotationPage)


### PR DESCRIPTION
## What does this do?

1. This adds a solution for Recipe 0014.
2. Attempts to address [Issue 199](https://github.com/iiif-prezi/iiif-prezi3/issues/199) by making add_item() available to AccompanyingCanvas.
3. Adds a test to check that members of items in AccompanyingCanvas are AnnotationPages when added with `add_item()`.