### PR TITLE
Create Thumbnail from IIIF

### DIFF
--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -1,7 +1,7 @@
 from ..loader import monkeypatch_schema
 from ..skeleton import (AccompanyingCanvas, Annotation, AnnotationCollection,
                         AnnotationPage, Canvas, Collection, Manifest,
-                        PlaceholderCanvas, Range, Reference, ResourceItem)
+                        PlaceholderCanvas, Range, Reference, ResourceItem, ServiceItem, ServiceItem1)
 
 
 class AddThumbnail:
@@ -20,6 +20,80 @@ class AddThumbnail:
             self.thumbnail = list()
         self.thumbnail.append(new_thumbnail)
         return new_thumbnail
+    
+    def create_thumbnail_from_iiif(self, url, preferred_width=500, **kwargs):
+        """Adds an image thumbnail to a manifest or canvas based on a IIIF service.
+
+        Args:
+            url (str): An HTTP URL which points at a IIIF Image response.
+            preferred_width (int, optional): the preferred width of the thumbnail.
+            **kwargs (): see ResourceItem.
+
+        Returns:
+            list[ResourceItem]: The updated list of thumbnails, including the newly-created one.
+        """
+        image_response = ResourceItem(id=url, type='Image')
+        image_info = image_response.set_hwd_from_iiif(url)
+        context = image_info.get('@context', '')
+        if context == "http://iiif.io/api/image/2/context.json":
+            if 'sizes' not in image_info:
+                thumbnail_id = f"{url}/full/full/0/default.jpg"
+            else:
+                best_fit_size = min(
+                    image_info.get('sizes'), key=lambda d: abs(d["width"] - preferred_width)
+                )
+                thumbnail_id = f"{url}/full/{best_fit_size['width']},{best_fit_size['height']}/0/default.jpg"
+            profile = next(
+                (item for item in image_info.get('profile', []) if isinstance(item, str)),
+                ''
+            )
+            service = ServiceItem1(
+                id=image_info['@id'],
+                profile=profile,
+                type="ImageService2",
+                format="image/jpeg"
+            )
+        else:
+            if 'sizes' not in image_info:
+                thumbnail_id = f"{url}/full/max/0/default.jpg"
+            service = ServiceItem(
+                id=image_info['id'],
+                profile=image_info.get('profile', ''),
+                type=image_info.get('type', 'ImageService'),
+                format="image/jpeg"
+            )
+        new_thumbnail = ResourceItem(
+            id=thumbnail_id,
+            type='Image',
+            # height=best_fit_size['height'],
+            # width=best_fit_size['width'],
+            format="image/jpeg",
+            **kwargs
+        )
+        if not hasattr(self, 'thumbnail') or self.thumbnail is None:
+            self.thumbnail = []
+        context = image_info.get('@context', '')
+        if context == "http://iiif.io/api/image/2/context.json":
+            profile = next(
+                (item for item in image_info.get('profile', []) if isinstance(item, str)),
+                ''
+            )
+            service = ServiceItem1(
+                id=image_info['@id'],
+                profile=profile,
+                type="ImageService2",
+                format="image/jpeg"
+            )
+        else:
+            service = ServiceItem(
+                id=image_info['id'],
+                profile=image_info.get('profile', ''),
+                type=image_info.get('type', 'ImageService'),
+                format="image/jpeg"
+            )
+        new_thumbnail.add_service(service)
+        self.thumbnail.append(new_thumbnail)
+        return self.thumbnail
 
 
 monkeypatch_schema([Canvas, PlaceholderCanvas, AccompanyingCanvas, AnnotationPage, Collection, Manifest, Annotation, Range, ResourceItem, AnnotationCollection, Reference], AddThumbnail)

--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -47,8 +47,7 @@ class AddThumbnail:
                 return f"{base_url}/full/{width},/0/default.jpg"
             else:
                 return f"{base_url}/full/{width},{height}/0/default.jpg"
-        level_0_profiles = {"http://iiif.io/api/image/2/level0.json", "level0"}
-        if profile not in level_0_profiles:
+        if profile not in ("http://iiif.io/api/image/2/level0.json", "level0"):
             if context == "http://iiif.io/api/image/2/context.json":
                 return f"{base_url}/full/{preferred_width},/0/default.jpg"
             else:

--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -31,7 +31,7 @@ class AddThumbnail:
             **kwargs (): see ResourceItem.
 
         Returns:
-            list[ResourceItem]: The updated list of thumbnails, including the newly-created one.
+            new_thumbnail (ResourceItem): The updated list of thumbnails, including the newly-created one.
         """
         image_response = ResourceItem(id=url, type='Image')
         image_info = image_response.set_hwd_from_iiif(url)

--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -23,7 +23,10 @@ class AddThumbnail:
         return new_thumbnail
 
     def create_thumbnail_from_iiif(self, url, preferred_width=500, **kwargs):
-        """Adds an image thumbnail to a manifest or canvas based on a IIIF service.
+        """Adds an image thumbnail to a manifest or canvas based on a IIIF service. If there is a sizes property, it
+        returns the thumbnail that is closest to the preferred width but larger. If no sizes property exists and it's
+        not level zero image service, it returns a thumbnail with the exact preferred width. Else, it returns the level
+        `full/full` or `full/max`.
 
         Args:
             url (str): An HTTP URL which points at a IIIF Image response.
@@ -36,15 +39,17 @@ class AddThumbnail:
         image_response = ResourceItem(id=url, type='Image')
         image_info = image_response.set_hwd_from_iiif(url)
         context = image_info.get('@context', '')
+        aspect_ratio = image_info.get('width') / image_info.get('height')
 
         if 'sizes' in image_info:
-            best_fit_size = max(
-                (size for size in image_info['sizes'] if size["width"] <= preferred_width),
+            best_fit_size = min(
+                (size for size in image_info['sizes'] if size["width"] >= preferred_width),
                 key=lambda size: size["width"],
-                default=image_info['sizes'][0]
+                default=image_info['sizes'][-1]
             )
             thumbnail_id = f"{url.replace('/info.json', '')}/full/{best_fit_size['width']},{best_fit_size['height']}/0/default.jpg"
         else:
+            # Set a default thumbnail in case of level 0 with no size property
             thumbnail_id = f"{url.replace('/info.json', '')}/full/full/0/default.jpg" if context == "http://iiif.io/api/image/2/context.json" else f"{url.replace('/info.json', '')}/full/max/0/default.jpg"
 
         if context == "http://iiif.io/api/image/2/context.json":
@@ -63,13 +68,18 @@ class AddThumbnail:
             )
             if profile == "http://iiif.io/api/image/2/level0.json" and 'sizes' in image_info:
                 thumbnail_id = f"{url.replace('/info.json', '')}/full/{best_fit_size['width']},/0/default.jpg"
+            elif profile != "http://iiif.io/api/image/2/level0.json" and 'sizes' not in image_info:
+                thumbnail_id = f"{url.replace('/info.json', '')}/full/{preferred_width},/0/default.jpg"
         else:
+            profile = image_info.get('profile', '')
             service = ServiceItem(
                 id=image_info['id'],
-                profile=image_info.get('profile', ''),
+                profile=profile,
                 type=image_info.get('type', 'ImageService'),
                 format="image/jpeg"
             )
+            if profile != "level0" and 'sizes' not in image_info:
+                thumbnail_id = f"{url.replace('/info.json', '')}/full/{preferred_width},{int(preferred_width/aspect_ratio)}/0/default.jpg"
 
         new_thumbnail = ResourceItem(
             id=thumbnail_id,
@@ -80,7 +90,10 @@ class AddThumbnail:
         if 'sizes' in image_info:
             new_thumbnail.height = best_fit_size.get('height')
             new_thumbnail.width = best_fit_size.get('width')
-        elif 'height' in image_info and 'width' in image_info:
+        elif profile != "http://iiif.io/api/image/2/level0.json" or 'profile' != "level0":
+            new_thumbnail.width = preferred_width
+            new_thumbnail.height = preferred_width/aspect_ratio
+        else:
             new_thumbnail.height = image_info['height']
             new_thumbnail.width = image_info['width']
 
@@ -93,4 +106,8 @@ class AddThumbnail:
         return self.thumbnail
 
 
-monkeypatch_schema([Canvas, PlaceholderCanvas, AccompanyingCanvas, AnnotationPage, Collection, Manifest, Annotation, Range, ResourceItem, AnnotationCollection, Reference], AddThumbnail)
+monkeypatch_schema(
+    [Canvas, PlaceholderCanvas, AccompanyingCanvas, AnnotationPage, Collection, Manifest, Annotation,
+     Range, ResourceItem, AnnotationCollection, Reference],
+    AddThumbnail
+)

--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -22,22 +22,6 @@ class AddThumbnail:
         self.thumbnail.append(new_thumbnail)
         return new_thumbnail
 
-    def handle_best_fit_size(self, url, image_info):
-        best_fit_size = None
-        context = image_info.get('@context', '')
-        if 'sizes' in image_info:
-            best_fit_size = min(
-                (size for size in image_info['sizes'] if size["width"] >= preferred_width),
-                key=lambda size: size["width"],
-                default=image_info['sizes'][-1]
-            )
-            if context == "http://iiif.io/api/image/2/context.json":
-                thumbnail_id = f"{url.replace('/info.json', '')}/full/{best_fit_size['width']},/0/default.jpg"
-            else:
-                thumbnail_id = f"{url.replace('/info.json', '')}/full/{best_fit_size['width']},{best_fit_size['height']}/0/default.jpg"
-        else:
-            thumbnail_id = f"{url.replace('/info.json', '')}/full/full/0/default.jpg" if context == "http://iiif.io/api/image/2/context.json" else f"{url.replace('/info.json', '')}/full/max/0/default.jpg"
-
     def __get_best_fit_size(self, image_info, preferred_width):
         if 'sizes' in image_info:
             return min(

--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -23,10 +23,11 @@ class AddThumbnail:
         return new_thumbnail
 
     def create_thumbnail_from_iiif(self, url, preferred_width=500, **kwargs):
-        """Adds an image thumbnail to a manifest or canvas based on a IIIF service. If there is a sizes property, it
-        returns the thumbnail that is closest to the preferred width but larger. If no sizes property exists and it's
-        not level zero image service, it returns a thumbnail with the exact preferred width. Else, it returns the level
-        `full/full` or `full/max`.
+        """Adds an image thumbnail to a manifest or canvas based on a IIIF service.
+
+        If there is a sizes property, it returns the thumbnail that is closest to the preferred width but larger. If no
+        sizes property exists and it's not level zero image service, it returns a thumbnail with the exact preferred
+        width. Else, it returns the level `full/full` or `full/max`.
 
         Args:
             url (str): An HTTP URL which points at a IIIF Image response.

--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -41,62 +41,60 @@ class AddThumbnail:
         image_info = image_response.set_hwd_from_iiif(url)
         context = image_info.get('@context', '')
         aspect_ratio = image_info.get('width') / image_info.get('height')
-
+        best_fit_size = None
         if 'sizes' in image_info:
             best_fit_size = min(
                 (size for size in image_info['sizes'] if size["width"] >= preferred_width),
                 key=lambda size: size["width"],
                 default=image_info['sizes'][-1]
             )
-            thumbnail_id = f"{url.replace('/info.json', '')}/full/{best_fit_size['width']},{best_fit_size['height']}/0/default.jpg"
+            if context == "http://iiif.io/api/image/2/context.json":
+                thumbnail_id = f"{url.replace('/info.json', '')}/full/{best_fit_size['width']},/0/default.jpg"
+            else:
+                thumbnail_id = f"{url.replace('/info.json', '')}/full/{best_fit_size['width']},{best_fit_size['height']}/0/default.jpg"
         else:
-            # Set a default thumbnail in case of level 0 with no size property
             thumbnail_id = f"{url.replace('/info.json', '')}/full/full/0/default.jpg" if context == "http://iiif.io/api/image/2/context.json" else f"{url.replace('/info.json', '')}/full/max/0/default.jpg"
 
-        if context == "http://iiif.io/api/image/2/context.json":
-            profile_data = image_info.get('profile', [])
-            if isinstance(profile_data, str):
-                profile = profile_data
-            elif isinstance(profile_data, list):
-                profile = next((item for item in profile_data if isinstance(item, str)), '')
-            else:
-                profile = ''
-            service = ServiceItem1(
+        profile_data = image_info.get('profile', [])
+        profile = (
+            profile_data if isinstance(profile_data, str)
+            else next((item for item in profile_data if isinstance(item, str)), '')
+            if isinstance(profile_data, list) else ''
+        )
+        service = (
+            ServiceItem1(
                 id=image_info['@id'],
                 profile=profile,
                 type="ImageService2",
                 format="image/jpeg"
             )
-            if profile == "http://iiif.io/api/image/2/level0.json" and 'sizes' in image_info:
-                thumbnail_id = f"{url.replace('/info.json', '')}/full/{best_fit_size['width']},/0/default.jpg"
-            elif profile != "http://iiif.io/api/image/2/level0.json" and 'sizes' not in image_info:
-                thumbnail_id = f"{url.replace('/info.json', '')}/full/{preferred_width},/0/default.jpg"
-        else:
-            profile = image_info.get('profile', '')
-            service = ServiceItem(
+            if context == "http://iiif.io/api/image/2/context.json"
+            else ServiceItem(
                 id=image_info['id'],
                 profile=profile,
                 type=image_info.get('type', 'ImageService'),
                 format="image/jpeg"
             )
-            if profile != "level0" and 'sizes' not in image_info:
-                thumbnail_id = f"{url.replace('/info.json', '')}/full/{preferred_width},{int(preferred_width/aspect_ratio)}/0/default.jpg"
-
-        new_thumbnail = ResourceItem(
-            id=thumbnail_id,
-            type='Image',
-            format="image/jpeg",
-            **kwargs
         )
-        if 'sizes' in image_info:
-            new_thumbnail.height = best_fit_size.get('height')
-            new_thumbnail.width = best_fit_size.get('width')
-        elif profile != "http://iiif.io/api/image/2/level0.json" or 'profile' != "level0":
-            new_thumbnail.width = preferred_width
-            new_thumbnail.height = preferred_width/aspect_ratio
+
+        if not best_fit_size:
+            if profile != "http://iiif.io/api/image/2/level0.json" or profile != "level0":
+                if context == "http://iiif.io/api/image/2/context.json":
+                    thumbnail_id = f"{url.replace('/info.json', '')}/full/{preferred_width},/0/default.jpg"
+                else:
+                    thumbnail_id = f"{url.replace('/info.json', '')}/full/{preferred_width},{int(preferred_width / aspect_ratio)}/0/default.jpg"
+            elif context == "http://iiif.io/api/image/2/context.json":
+                thumbnail_id = f"{url.replace('/info.json', '')}/full/full/0/default.jpg"
+            else:
+                thumbnail_id = f"{url.replace('/info.json', '')}/full/max/0/default.jpg"
+
+        new_thumbnail = ResourceItem(id=thumbnail_id, type='Image', format="image/jpeg", **kwargs)
+        if best_fit_size:
+            new_thumbnail.width = best_fit_size['width']
+            new_thumbnail.height = best_fit_size['height']
         else:
-            new_thumbnail.height = image_info['height']
-            new_thumbnail.width = image_info['width']
+            new_thumbnail.width = preferred_width
+            new_thumbnail.height = int(preferred_width / aspect_ratio)
 
         if not hasattr(self, 'thumbnail') or self.thumbnail is None:
             self.thumbnail = []

--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -40,7 +40,8 @@ class AddThumbnail:
         if 'sizes' in image_info:
             best_fit_size = max(
                 (size for size in image_info['sizes'] if size["width"] <= preferred_width),
-                key=lambda size: size["width"]
+                key=lambda size: size["width"],
+                default=image_info['sizes'][0]
             )
             thumbnail_id = f"{url.replace('/info.json', '')}/full/{best_fit_size['width']},{best_fit_size['height']}/0/default.jpg"
         else:

--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -1,7 +1,8 @@
 from ..loader import monkeypatch_schema
 from ..skeleton import (AccompanyingCanvas, Annotation, AnnotationCollection,
                         AnnotationPage, Canvas, Collection, Manifest,
-                        PlaceholderCanvas, Range, Reference, ResourceItem, ServiceItem, ServiceItem1)
+                        PlaceholderCanvas, Range, Reference, ResourceItem,
+                        ServiceItem, ServiceItem1)
 
 
 class AddThumbnail:
@@ -20,7 +21,7 @@ class AddThumbnail:
             self.thumbnail = list()
         self.thumbnail.append(new_thumbnail)
         return new_thumbnail
-    
+
     def create_thumbnail_from_iiif(self, url, preferred_width=500, **kwargs):
         """Adds an image thumbnail to a manifest or canvas based on a IIIF service.
 
@@ -70,6 +71,9 @@ class AddThumbnail:
         if 'sizes' in image_info:
             new_thumbnail.height = best_fit_size.get('height')
             new_thumbnail.width = best_fit_size.get('width')
+        elif 'height' in image_info and 'width' in image_info:
+            new_thumbnail.height = image_info['height']
+            new_thumbnail.width = image_info['width']
 
         if not hasattr(self, 'thumbnail') or self.thumbnail is None:
             self.thumbnail = []

--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -32,13 +32,17 @@ class AddThumbnail:
         else:
             return None
 
-    def __get_thumbnail_id(self, url, image_info, best_fit, preferred_width, aspect_ratio):
-        context = image_info.get('@context', '')
+    def __get_profile(self, image_info):
         profile_data = image_info.get('profile', [])
         if isinstance(profile_data, list):
-            profile = next((item for item in profile_data if isinstance(item, str)), '')
+            return profile_data[0]
         else:
-            profile = profile_data
+            return profile_data
+
+
+    def __get_thumbnail_id(self, url, image_info, best_fit, preferred_width, aspect_ratio):
+        context = image_info.get('@context', '')
+        profile = self.__get_profile(image_info)
         base_url = url.replace('/info.json', '')
         if best_fit:
             width = best_fit['width']
@@ -77,12 +81,7 @@ class AddThumbnail:
         image_info = image_response.set_hwd_from_iiif(url)
         context = image_info.get('@context', '')
         aspect_ratio = image_info.get('width') / image_info.get('height')
-        profile_data = image_info.get('profile', [])
-        profile = (
-            profile_data if isinstance(profile_data, str)
-            else next((item for item in profile_data if isinstance(item, str)), '')
-            if isinstance(profile_data, list) else ''
-        )
+        profile = self.__get_profile(image_info)
         best_fit_size = self.__get_best_fit_size(image_info, preferred_width)
         thumbnail_id = self.__get_thumbnail_id(url, image_info, best_fit_size, preferred_width, aspect_ratio)
 

--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -22,7 +22,8 @@ class AddThumbnail:
         self.thumbnail.append(new_thumbnail)
         return new_thumbnail
 
-    def __get_best_fit_size(self, image_info, preferred_width):
+    @staticmethod
+    def __get_best_fit_size(image_info, preferred_width):
         if 'sizes' in image_info:
             return min(
                 (size for size in image_info['sizes'] if size["width"] >= preferred_width),
@@ -32,8 +33,9 @@ class AddThumbnail:
         else:
             return None
 
-    def __get_profile(self, image_info):
-        profile_data = image_info.get('profile', [])
+    @staticmethod
+    def __get_profile(image_info):
+        profile_data = image_info.get('profile', [''])
         if isinstance(profile_data, list):
             return profile_data[0]
         else:

--- a/tests/test_add_thumbnail.py
+++ b/tests/test_add_thumbnail.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from iiif_prezi3 import Manifest
+
+
+class AddThumbnailTests(unittest.TestCase):
+
+    def setUp(self):
+        self.manifest = Manifest(label={'en': ['Manifest label']})
+
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    def test_create_thumbnail_from_iiif_v3(self, mockrequest_get):
+        image_id = 'https://fixtures.iiif.io/other/level0/Glen/photos/gottingen'
+        image_info_url = f'{image_id}/info.json'
+
+        # successful response with dimensions
+        mockresponse = Mock(status_code=200)
+        mockrequest_get.return_value = mockresponse
+        # set mock to return minimal image api response
+        mockresponse.json.return_value = {
+            "@context": "http://iiif.io/api/image/3/context.json",
+            "id": "https://fixtures.iiif.io/other/level0/Glen/photos/gottingen",
+            "type": "ImageService3",
+            "protocol": "http://iiif.io/api/image",
+            "profile": "level0",
+            "width": 4032,
+            "height": 3024,
+            "sizes": [
+                {
+                  "width": 126,
+                  "height": 95
+                },
+                {
+                    "width": 252,
+                    "height": 189
+                },
+                {
+                    "width": 504,
+                    "height": 378
+                },
+                {
+                    "width": 1008,
+                    "height": 756
+                },
+                {
+                    "width": 2016,
+                    "height": 1512
+                },
+                {
+                    "width": 4032,
+                    "height": 3024
+                }
+            ]
+        }
+
+        thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
+
+        # check thumbnail matches preferred size
+        self.assertEqual(thumbnail.height, 378)
+        self.assertEqual(thumbnail.width, 504)
+
+        # check thumbnail id
+        self.assertEqual(thumbnail.id, "https://fixtures.iiif.io/other/level0/Glen/photos/gottingen/full/504,378/0/default.jpg")
+
+        # check thumbnail service
+        service = thumbnail.service[0]
+        self.assertEqual(service['profile'], "level0")
+        self.assertEqual(service['type'], "ImageService3")

--- a/tests/test_add_thumbnail.py
+++ b/tests/test_add_thumbnail.py
@@ -10,7 +10,185 @@ class AddThumbnailTests(unittest.TestCase):
         self.manifest = Manifest(label={'en': ['Manifest label']})
 
     @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
-    def test_create_thumbnail_from_iiif_v3(self, mockrequest_get):
+    def test_create_thumbnail_from_iiif_v3_sizes_not_level_0(self, mockrequest_get):
+        # This fixture is hosted by UCLA but used in Recipe 0234-provider
+        image_id = 'https://iiif.library.ucla.edu/iiif/3/UCLA-Library-Logo-double-line-2'
+        image_info_url = f'{image_id}/info.json'
+
+        # successful response with dimensions
+        mockresponse = Mock(status_code=200)
+        mockrequest_get.return_value = mockresponse
+        # set mock to return minimal image api response
+        mockresponse.json.return_value = {
+          "@context": "http://iiif.io/api/image/3/context.json",
+          "id": "https://iiif.library.ucla.edu/iiif/3/UCLA-Library-Logo-double-line-2",
+          "type": "ImageService3",
+          "protocol": "http://iiif.io/api/image",
+          "profile": "level2",
+          "width": 1200,
+          "height": 502,
+          "maxArea": 602400,
+          "sizes": [
+            {
+              "width": 300,
+              "height": 126
+            },
+            {
+              "width": 600,
+              "height": 251
+            },
+            {
+              "width": 1200,
+              "height": 502
+            }
+          ],
+          "tiles": [
+            {
+              "width": 512,
+              "height": 502,
+              "scaleFactors": [
+                1,
+                2,
+                4
+              ]
+            }
+          ],
+          "extraQualities": [
+            "bitonal",
+            "color",
+            "gray"
+          ],
+          "extraFormats": [
+            "tif",
+            "gif"
+          ],
+          "extraFeatures": [
+            "baseUriRedirect",
+            "canonicalLinkHeader",
+            "cors",
+            "jsonldMediaType",
+            "mirroring",
+            "profileLinkHeader",
+            "regionByPct",
+            "regionByPx",
+            "regionSquare",
+            "rotationArbitrary",
+            "rotationBy90s",
+            "sizeByConfinedWh",
+            "sizeByH",
+            "sizeByPct",
+            "sizeByW",
+            "sizeByWh"
+          ]
+        }
+
+        thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
+
+        # check thumbnail matches preferred size
+        self.assertEqual(thumbnail.height, 251)
+        self.assertEqual(thumbnail.width, 600)
+
+        # check thumbnail id
+        self.assertEqual(
+            thumbnail.id,
+            f"{image_id}/full/600,251/0/default.jpg"
+        )
+
+        # check thumbnail service
+        self.assertEqual(thumbnail.service[0].profile, "level2")
+        self.assertEqual(thumbnail.service[0].type, "ImageService3")
+
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    def test_create_thumbnail_from_iiif_v2_sizes_not_level_0(self, mockrequest_get):
+        # This fixture is hosted by UCLA but used in Recipe 0234-provider
+        image_id = 'https://iiif.library.ucla.edu/iiif/2/UCLA-Library-Logo-double-line-2'
+        image_info_url = f'{image_id}/info.json'
+
+        # successful response with dimensions
+        mockresponse = Mock(status_code=200)
+        mockrequest_get.return_value = mockresponse
+        # set mock to return minimal image api response
+        mockresponse.json.return_value = {
+            "@context": "http://iiif.io/api/image/3/context.json",
+            "id": "https://iiif.library.ucla.edu/iiif/3/UCLA-Library-Logo-double-line-2",
+            "type": "ImageService3",
+            "protocol": "http://iiif.io/api/image",
+            "profile": "level2",
+            "width": 1200,
+            "height": 502,
+            "maxArea": 602400,
+            "sizes": [
+                {
+                    "width": 300,
+                    "height": 126
+                },
+                {
+                    "width": 600,
+                    "height": 251
+                },
+                {
+                    "width": 1200,
+                    "height": 502
+                }
+            ],
+            "tiles": [
+                {
+                    "width": 512,
+                    "height": 502,
+                    "scaleFactors": [
+                        1,
+                        2,
+                        4
+                    ]
+                }
+            ],
+            "extraQualities": [
+                "bitonal",
+                "color",
+                "gray"
+            ],
+            "extraFormats": [
+                "tif",
+                "gif"
+            ],
+            "extraFeatures": [
+                "baseUriRedirect",
+                "canonicalLinkHeader",
+                "cors",
+                "jsonldMediaType",
+                "mirroring",
+                "profileLinkHeader",
+                "regionByPct",
+                "regionByPx",
+                "regionSquare",
+                "rotationArbitrary",
+                "rotationBy90s",
+                "sizeByConfinedWh",
+                "sizeByH",
+                "sizeByPct",
+                "sizeByW",
+                "sizeByWh"
+            ]
+        }
+
+        thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
+
+        # check thumbnail matches preferred size
+        self.assertEqual(thumbnail.height, 251)
+        self.assertEqual(thumbnail.width, 600)
+
+        # check thumbnail id
+        self.assertEqual(
+            thumbnail.id,
+            f"{image_id}/full/600,251/0/default.jpg"
+        )
+
+        # check thumbnail service
+        self.assertEqual(thumbnail.service[0].profile, "level2")
+        self.assertEqual(thumbnail.service[0].type, "ImageService3")
+
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    def test_create_thumbnail_from_iiif_v3_sizes_level0(self, mockrequest_get):
         image_id = 'https://fixtures.iiif.io/other/level0/Glen/photos/gottingen'
         image_info_url = f'{image_id}/info.json'
 
@@ -57,133 +235,13 @@ class AddThumbnailTests(unittest.TestCase):
         thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
 
         # check thumbnail matches preferred size
-        self.assertEqual(thumbnail.height, 189)
-        self.assertEqual(thumbnail.width, 252)
+        self.assertEqual(thumbnail.height, 378)
+        self.assertEqual(thumbnail.width, 504)
 
         # check thumbnail id
-        self.assertEqual(thumbnail.id, "https://fixtures.iiif.io/other/level0/Glen/photos/gottingen/full/252,189/0/default.jpg")
-
-        # check thumbnail service
-        self.assertEqual(thumbnail.service[0].profile, "level0")
-        self.assertEqual(thumbnail.service[0].type, "ImageService3")
-
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
-    def test_create_thumbnail_from_iiif_v2(self, mockrequest_get):
-        image_id = 'https://iiif.io/api/image/2.1/example/reference/918ecd18c2592080851777620de9bcb5-gottingen'
-        image_info_url = f'{image_id}/info.json'
-
-        # successful response with dimensions
-        mockresponse = Mock(status_code=200)
-        mockrequest_get.return_value = mockresponse
-        # set mock to return minimal image api response
-        mockresponse.json.return_value = {
-            "@context": "http://iiif.io/api/image/2/context.json",
-            "@id": "https://iiif.io/api/image/2.1/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
-            "height": 3024,
-            "profile": [
-                "http://iiif.io/api/image/2/level1.json",
-                {
-                    "formats": [
-                        "jpg",
-                        "png"
-                    ],
-                    "qualities": [
-                        "default",
-                        "color",
-                        "gray"
-                    ]
-                }
-            ],
-            "protocol": "http://iiif.io/api/image",
-            "tiles": [
-                {
-                    "height": 512,
-                    "scaleFactors": [
-                        1,
-                        2,
-                        4
-                    ],
-                    "width": 512
-                }
-            ],
-            "width": 4032
-        }
-
-        thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
-
-        # check thumbnail matches preferred size
-        self.assertEqual(thumbnail.height, 3024)
-        self.assertEqual(thumbnail.width, 4032)
-
-        # Since info_json has no sizes, use full/full
-        self.assertEqual(thumbnail.id, "https://iiif.io/api/image/2.1/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/full/full/0/default.jpg")
-
-        # check thumbnail service
-        self.assertEqual(thumbnail.service[0].profile, "http://iiif.io/api/image/2/level1.json")
-        self.assertEqual(thumbnail.service[0].type, "ImageService2")
-
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
-    def test_create_thumbnail_from_level_0_iiif_v3(self, mockrequest_get):
-        image_id = 'https://iiif-test.github.io/test2/images/IMG_5949'
-        image_info_url = f'{image_id}/info.json'
-        mockresponse = Mock(status_code=200)
-        mockrequest_get.return_value = mockresponse
-        mockresponse.json.return_value = {
-          "tiles": [
-            {
-              "scaleFactors": [
-                32,
-                16,
-                8,
-                4,
-                2,
-                1
-              ],
-              "width": 1024,
-              "height": 1024
-            }
-          ],
-          "protocol": "http://iiif.io/api/image",
-          "sizes": [
-            {
-              "width": 126,
-              "height": 95
-            },
-            {
-              "width": 252,
-              "height": 189
-            },
-            {
-              "width": 504,
-              "height": 378
-            },
-            {
-              "width": 1008,
-              "height": 756
-            },
-            {
-              "width": 2016,
-              "height": 1512
-            },
-            {
-              "width": 4032,
-              "height": 3024
-            }
-          ],
-          "profile": "level0",
-          "width": 4032,
-          "id": "https://iiif-test.github.io/test2/images/IMG_5949",
-          "type": "ImageService3",
-          "@context": "http://iiif.io/api/image/3/context.json",
-          "height": 3024
-        }
-
-        thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
-        self.assertEqual(thumbnail.height, 189)
-        self.assertEqual(thumbnail.width, 252)
         self.assertEqual(
             thumbnail.id,
-    "https://iiif-test.github.io/test2/images/IMG_5949/full/252,189/0/default.jpg"
+            f"{image_id}/full/504,378/0/default.jpg"
         )
 
         # check thumbnail service
@@ -191,7 +249,7 @@ class AddThumbnailTests(unittest.TestCase):
         self.assertEqual(thumbnail.service[0].type, "ImageService3")
 
     @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
-    def test_create_thumbnail_from_level_0_iiif_v2(self, mockrequest_get):
+    def test_create_thumbnail_from_level_0_iiif_v2_sizes_level0(self, mockrequest_get):
         image_id = 'https://iiif-test.github.io/test2/images/IMG_8669'
         image_info_url = f'{image_id}/info.json'
         mockresponse = Mock(status_code=200)
@@ -246,9 +304,172 @@ class AddThumbnailTests(unittest.TestCase):
         }
 
         thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
-        self.assertEqual(thumbnail.height, 189)
-        self.assertEqual(thumbnail.width, 252)
+        self.assertEqual(thumbnail.height, 378)
+        self.assertEqual(thumbnail.width, 504)
         self.assertEqual(
             thumbnail.id,
-            "https://iiif-test.github.io/test2/images/IMG_8669/full/252,/0/default.jpg"
+            "https://iiif-test.github.io/test2/images/IMG_8669/full/504,/0/default.jpg"
+        )
+
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    def test_v3_with_no_sizes_prop(self, mockrequest_get):
+        image_id = 'https://iiif.io/api/image/3.0/example/reference/4ce82cef49fb16798f4c2440307c3d6f-newspaper-p1'
+        image_info_url = f'{image_id}/info.json'
+        mockresponse = Mock(status_code=200)
+        mockrequest_get.return_value = mockresponse
+        mockresponse.json.return_value = {
+          "@context": "http://iiif.io/api/image/3/context.json",
+          "extraFormats": [
+            "jpg",
+            "png"
+          ],
+          "extraQualities": [
+            "default",
+            "color",
+            "gray"
+          ],
+          "height": 5000,
+          "id": "https://iiif.io/api/image/3.0/example/reference/4ce82cef49fb16798f4c2440307c3d6f-newspaper-p1",
+          "profile": "level1",
+          "protocol": "http://iiif.io/api/image",
+          "tiles": [
+            {
+              "height": 512,
+              "scaleFactors": [
+                1,
+                2,
+                4,
+                8
+              ],
+              "width": 512
+            }
+          ],
+          "type": "ImageService3",
+          "width": 3602
+        }
+
+        thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
+        self.assertEqual(thumbnail.height, 694)
+        self.assertEqual(thumbnail.width, 500)
+        self.assertEqual(
+            thumbnail.id,
+            f"{image_id}/full/500,694/0/default.jpg"
+        )
+
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    def test_create_thumbnail_from_iiif_v2_no_sizes(self, mockrequest_get):
+        image_id = 'https://iiif.io/api/image/2.1/example/reference/918ecd18c2592080851777620de9bcb5-gottingen'
+        image_info_url = f'{image_id}/info.json'
+
+        # successful response with dimensions
+        mockresponse = Mock(status_code=200)
+        mockrequest_get.return_value = mockresponse
+        # set mock to return minimal image api response
+        mockresponse.json.return_value = {
+            "@context": "http://iiif.io/api/image/2/context.json",
+            "@id": "https://iiif.io/api/image/2.1/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
+            "height": 3024,
+            "profile": [
+                "http://iiif.io/api/image/2/level1.json",
+                {
+                    "formats": [
+                        "jpg",
+                        "png"
+                    ],
+                    "qualities": [
+                        "default",
+                        "color",
+                        "gray"
+                    ]
+                }
+            ],
+            "protocol": "http://iiif.io/api/image",
+            "tiles": [
+                {
+                    "height": 512,
+                    "scaleFactors": [
+                        1,
+                        2,
+                        4
+                    ],
+                    "width": 512
+                }
+            ],
+            "width": 4032
+        }
+
+        thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
+
+        # check thumbnail matches preferred size
+        self.assertEqual(thumbnail.height, 375)
+        self.assertEqual(thumbnail.width, 500)
+
+        # Since info_json has no sizes, use full/full
+        self.assertEqual(thumbnail.id, "https://iiif.io/api/image/2.1/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/full/500,/0/default.jpg")
+
+        # check thumbnail service
+        self.assertEqual(thumbnail.service[0].profile, "http://iiif.io/api/image/2/level1.json")
+        self.assertEqual(thumbnail.service[0].type, "ImageService2")
+
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    def test_create_thumbnail_from_iiif_giant_request_with_sizes(self, mockrequest_get):
+        image_id = 'https://iiif-test.github.io/test2/images/IMG_8669'
+        image_info_url = f'{image_id}/info.json'
+        mockresponse = Mock(status_code=200)
+        mockrequest_get.return_value = mockresponse
+        mockresponse.json.return_value = {
+          "tiles": [
+            {
+              "scaleFactors": [
+                32,
+                16,
+                8,
+                4,
+                2,
+                1
+              ],
+              "width": 1024,
+              "height": 1024
+            }
+          ],
+          "protocol": "http://iiif.io/api/image",
+          "sizes": [
+            {
+              "width": 126,
+              "height": 95
+            },
+            {
+              "width": 252,
+              "height": 189
+            },
+            {
+              "width": 504,
+              "height": 378
+            },
+            {
+              "width": 1008,
+              "height": 756
+            },
+            {
+              "width": 2016,
+              "height": 1512
+            },
+            {
+              "width": 4032,
+              "height": 3024
+            }
+          ],
+          "profile": "http://iiif.io/api/image/2/level0.json",
+          "width": 4032,
+          "@id": "https://iiif-test.github.io/test2/images/IMG_8669",
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "height": 3024
+        }
+
+        giant_thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url, preferred_width=7000)[0]
+        self.assertEqual(giant_thumbnail.height, 3024)
+        self.assertEqual(giant_thumbnail.width, 4032)
+        self.assertEqual(
+            giant_thumbnail.id,
+            f"{image_id}/full/4032,/0/default.jpg"
         )

--- a/tests/test_add_thumbnail.py
+++ b/tests/test_add_thumbnail.py
@@ -57,11 +57,11 @@ class AddThumbnailTests(unittest.TestCase):
         thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
 
         # check thumbnail matches preferred size
-        self.assertEqual(thumbnail.height, 378)
-        self.assertEqual(thumbnail.width, 504)
+        self.assertEqual(thumbnail.height, 189)
+        self.assertEqual(thumbnail.width, 252)
 
         # check thumbnail id
-        self.assertEqual(thumbnail.id, "https://fixtures.iiif.io/other/level0/Glen/photos/gottingen/full/504,378/0/default.jpg")
+        self.assertEqual(thumbnail.id, "https://fixtures.iiif.io/other/level0/Glen/photos/gottingen/full/252,189/0/default.jpg")
 
         # check thumbnail service
         self.assertEqual(thumbnail.service[0].profile, "level0")
@@ -121,3 +121,134 @@ class AddThumbnailTests(unittest.TestCase):
         # check thumbnail service
         self.assertEqual(thumbnail.service[0].profile, "http://iiif.io/api/image/2/level1.json")
         self.assertEqual(thumbnail.service[0].type, "ImageService2")
+
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    def test_create_thumbnail_from_level_0_iiif_v3(self, mockrequest_get):
+        image_id = 'https://iiif-test.github.io/test2/images/IMG_5949'
+        image_info_url = f'{image_id}/info.json'
+        mockresponse = Mock(status_code=200)
+        mockrequest_get.return_value = mockresponse
+        mockresponse.json.return_value = {
+          "tiles": [
+            {
+              "scaleFactors": [
+                32,
+                16,
+                8,
+                4,
+                2,
+                1
+              ],
+              "width": 1024,
+              "height": 1024
+            }
+          ],
+          "protocol": "http://iiif.io/api/image",
+          "sizes": [
+            {
+              "width": 126,
+              "height": 95
+            },
+            {
+              "width": 252,
+              "height": 189
+            },
+            {
+              "width": 504,
+              "height": 378
+            },
+            {
+              "width": 1008,
+              "height": 756
+            },
+            {
+              "width": 2016,
+              "height": 1512
+            },
+            {
+              "width": 4032,
+              "height": 3024
+            }
+          ],
+          "profile": "level0",
+          "width": 4032,
+          "id": "https://iiif-test.github.io/test2/images/IMG_5949",
+          "type": "ImageService3",
+          "@context": "http://iiif.io/api/image/3/context.json",
+          "height": 3024
+        }
+
+        thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
+        self.assertEqual(thumbnail.height, 189)
+        self.assertEqual(thumbnail.width, 252)
+        self.assertEqual(
+            thumbnail.id,
+    "https://iiif-test.github.io/test2/images/IMG_5949/full/252,189/0/default.jpg"
+        )
+
+        # check thumbnail service
+        self.assertEqual(thumbnail.service[0].profile, "level0")
+        self.assertEqual(thumbnail.service[0].type, "ImageService3")
+
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    def test_create_thumbnail_from_level_0_iiif_v2(self, mockrequest_get):
+        image_id = 'https://iiif-test.github.io/test2/images/IMG_8669'
+        image_info_url = f'{image_id}/info.json'
+        mockresponse = Mock(status_code=200)
+        mockrequest_get.return_value = mockresponse
+        mockresponse.json.return_value = {
+          "tiles": [
+            {
+              "scaleFactors": [
+                32,
+                16,
+                8,
+                4,
+                2,
+                1
+              ],
+              "width": 1024,
+              "height": 1024
+            }
+          ],
+          "protocol": "http://iiif.io/api/image",
+          "sizes": [
+            {
+              "width": 126,
+              "height": 95
+            },
+            {
+              "width": 252,
+              "height": 189
+            },
+            {
+              "width": 504,
+              "height": 378
+            },
+            {
+              "width": 1008,
+              "height": 756
+            },
+            {
+              "width": 2016,
+              "height": 1512
+            },
+            {
+              "width": 4032,
+              "height": 3024
+            }
+          ],
+          "profile": "http://iiif.io/api/image/2/level0.json",
+          "width": 4032,
+          "@id": "https://iiif-test.github.io/test2/images/IMG_8669",
+          "@context": "http://iiif.io/api/image/2/context.json",
+          "height": 3024
+        }
+
+        thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
+        self.assertEqual(thumbnail.height, 189)
+        self.assertEqual(thumbnail.width, 252)
+        self.assertEqual(
+            thumbnail.id,
+            "https://iiif-test.github.io/test2/images/IMG_8669/full/252,/0/default.jpg"
+        )

--- a/tests/test_add_thumbnail.py
+++ b/tests/test_add_thumbnail.py
@@ -64,6 +64,5 @@ class AddThumbnailTests(unittest.TestCase):
         self.assertEqual(thumbnail.id, "https://fixtures.iiif.io/other/level0/Glen/photos/gottingen/full/504,378/0/default.jpg")
 
         # check thumbnail service
-        service = thumbnail.service[0]
-        self.assertEqual(service['profile'], "level0")
-        self.assertEqual(service['type'], "ImageService3")
+        self.assertEqual(thumbnail.service[0].profile, "level0")
+        self.assertEqual(thumbnail.service[0].type, "ImageService3")


### PR DESCRIPTION
# What Does This Do

This adds a new helper  on `AddThumbnail` called `create_thumbnail_from_iiif()`. This allows someone to generate a thumbnail from an image info response that is v2 or v3.  It optionally takes an argument `preferred_width` that will choose the best thumbnail if a `sizes` property exists in the info.json (defaults to 500). If no `sizes` property exists, it just takes the full sized image as `full/full` for v2 or `full/max` for v3. This seems like the safest way to approach in case of a level 0 image service.

Some of the patterns here are inspired by previous helpers, but I chose to add the method to the existing AddThumbnail class rather than create a brand  new helper class from scratch.  My thinking about this was to try and keep all thumbnail helpers together. I'd like to add another helper method that let's you create preview thumbnails for videos, so my thinking was to try and reduce the amount of classes, but if each helper method needs its own class, I can refactor this.