### PR TITLE
Attempt to address Issue-191.

### DIFF
--- a/iiif_prezi3/helpers/auto_fields.py
+++ b/iiif_prezi3/helpers/auto_fields.py
@@ -2,8 +2,8 @@ import uuid
 
 from ..config.config import Config, register_config
 from ..skeleton import (AnnotationPage, Canvas, Class, HomepageItem,
-                        KeyValueString, NavPlace, ProviderItem, Range,
-                        Reference, ResourceItem, ServiceItem1)
+                        KeyValueString, ManifestRef, NavPlace, ProviderItem,
+                        Range, Reference, ResourceItem, ServiceItem1)
 
 
 class AutoConfig(Config):
@@ -179,8 +179,8 @@ ait = AutoItems(aitcfg)
 alst = AutoList(alstcfg, name="General")
 allst = AutoList(allstcfg, name="Language")
 # Set up some obvious defaults
-ai.register_on_class(AnnotationPage, Class)
-al.register_on_class(KeyValueString, Class, Reference, ResourceItem)
+ai.register_on_class(AnnotationPage, Class, ManifestRef)
+al.register_on_class(KeyValueString, Class, Reference, ResourceItem, ManifestRef)
 ait.register_on_class(Canvas, Range, AnnotationPage)
 alst.register_on_class(Class, AnnotationPage, ResourceItem, ServiceItem1, NavPlace, Reference, ProviderItem)
 allst.register_on_class(HomepageItem)

--- a/iiif_prezi3/helpers/make_manifest.py
+++ b/iiif_prezi3/helpers/make_manifest.py
@@ -1,19 +1,19 @@
 from ..loader import monkeypatch_schema
-from ..skeleton import Collection, Manifest
+from ..skeleton import Collection, ManifestRef
 
 
 class MakeManifest:
 
     def make_manifest(self, **kwargs):
-        """Add a Manifest to a Collection.
+        """Add a Manifest to a Collection as a ManifestRef.
 
         Creates a new Manifest, adds a Reference to it to the
         calling Collection items and returns the newly created Manifest.
         Accepts keyword arguments to customize the resulting instance.
         """
-        manifest = Manifest(**kwargs)
+        manifest = ManifestRef(**kwargs)
         self.add_item(manifest)
-        return manifest
 
+        return manifest
 
 monkeypatch_schema(Collection, MakeManifest)

--- a/tests/test_make_manifest.py
+++ b/tests/test_make_manifest.py
@@ -1,6 +1,6 @@
 import unittest
 
-from iiif_prezi3 import Collection, Reference, HomepageItem, config
+from iiif_prezi3 import Collection, HomepageItem, Reference, config
 
 
 class MakeManifestTest(unittest.TestCase):
@@ -26,4 +26,4 @@ class MakeManifestTest(unittest.TestCase):
         self.assertIsInstance(self.collection.items[0], Reference)
         self.assertEqual(manifest.label,
                          {'en': ['default label']})
-        self.assertEqual(manifest.homepage[0], homepage)
+        self.assertEqual(manifest.homepage, homepage)

--- a/tests/test_make_manifest.py
+++ b/tests/test_make_manifest.py
@@ -1,6 +1,6 @@
 import unittest
 
-from iiif_prezi3 import Collection, Reference
+from iiif_prezi3 import Collection, Reference, HomepageItem, config
 
 
 class MakeManifestTest(unittest.TestCase):
@@ -9,9 +9,21 @@ class MakeManifestTest(unittest.TestCase):
         self.collection = Collection()
 
     def test_make_manifest(self):
+        config.configs['helpers.auto_fields.AutoLang'].auto_lang = "en"
+        homepage = HomepageItem(
+            id="https://www.getty.edu/art/collection/object/103RQQ",
+            type="Text",
+            label="Home page at the Getty Museum Collection",
+            format="text/html",
+            language=["en"]
+        )
         manifest = self.collection.make_manifest(
-            label={'en': ['default label']})
+            id='http://example.org/iiif/1',
+            label='default label',
+            homepage=homepage,
+        )
         self.assertEqual(len(self.collection.items), 1)
         self.assertIsInstance(self.collection.items[0], Reference)
         self.assertEqual(manifest.label,
                          {'en': ['default label']})
+        self.assertEqual(manifest.homepage[0], homepage)


### PR DESCRIPTION
# What Does this Do

This attempts to address [Issue-191](https://github.com/iiif-prezi/iiif-prezi3/issues/191).  That issue describes a problem where `homepage` props are dropped from Manifests in a Collection if the manifest was created via the `make_ manifest()` helper.  Oddly, the issue doesn't exist if manifests are created and added to the Collection in other ways.

The issue appears to be that the helper uses the `Manifest` class rather than `ManifestRef`.  If we switch the classes, things seem to work as expected.  

Todo: **what if items prop exists in incoming kwargs?**

# Any potential regressions

I don't think so. I've added ManifestRef to the AutoIdConfig helper incase someone was using `make_manifest()` without adding an `id` property since that worked on Manifest but not ManifestRef.  I've also had to add `ManifestRef` to the AutoLang helper.  For some reason, this doesn't work on `ManifestRef` even though `Reference` is listed.