### PR TITLE
Attempt to Address Issue-225 and Issue-226.

### DIFF
--- a/iiif_prezi3/helpers/make_collection.py
+++ b/iiif_prezi3/helpers/make_collection.py
@@ -1,17 +1,22 @@
 from ..loader import monkeypatch_schema
-from ..skeleton import Collection
+from ..skeleton import Collection, CollectionRef
 
 
 class MakeCollection:
 
     def make_collection(self, **kwargs):
-        """Create a Collection.
+        """Creates a Collection or CollectionRef.
 
         Creates a new collection, adds it to the calling Collection `items`
         and returns the newly created object. Accepts keyword arguments to
         customize the resulting instance.
         """
-        child_collection = Collection(**kwargs)
+        if 'items' not in kwargs:
+            child_collection = CollectionRef(**kwargs)
+        elif len(kwargs['items']) == 0:
+            child_collection = CollectionRef(**kwargs)
+        else:
+            child_collection = Collection(**kwargs)
         self.add_item(child_collection)
         return child_collection
 

--- a/iiif_prezi3/helpers/make_collection.py
+++ b/iiif_prezi3/helpers/make_collection.py
@@ -11,9 +11,8 @@ class MakeCollection:
         and returns the newly created object. Accepts keyword arguments to
         customize the resulting instance.
         """
-        if 'items' not in kwargs:
-            child_collection = CollectionRef(**kwargs)
-        elif len(kwargs['items']) == 0:
+        if 'items' not in kwargs or not kwargs['items']:
+            kwargs.pop('items')
             child_collection = CollectionRef(**kwargs)
         else:
             child_collection = Collection(**kwargs)

--- a/iiif_prezi3/helpers/make_collection.py
+++ b/iiif_prezi3/helpers/make_collection.py
@@ -5,19 +5,24 @@ from ..skeleton import Collection, CollectionRef
 class MakeCollection:
 
     def make_collection(self, **kwargs):
-        """Creates a Collection or CollectionRef.
+        """Create a Collection.
 
         Creates a new collection, adds it to the calling Collection `items`
         and returns the newly created object. Accepts keyword arguments to
         customize the resulting instance.
         """
-        if 'items' not in kwargs:
-            child_collection = CollectionRef(**kwargs)
-        elif not kwargs['items']:
-            kwargs.pop('items')
-            child_collection = CollectionRef(**kwargs)
-        else:
-            child_collection = Collection(**kwargs)
+        child_collection = Collection(**kwargs)
+        self.add_item(child_collection)
+        return child_collection
+
+    def make_collection_ref(self, **kwargs):
+        """Creates a CollectionRef.
+
+        Creates a new CollectionRef, adds it to the calling Collection `items`
+        and returns the newly created object. Accepts keyword arguments to
+        customize the resulting instance.
+        """
+        child_collection = CollectionRef(**kwargs)
         self.add_item(child_collection)
         return child_collection
 

--- a/iiif_prezi3/helpers/make_collection.py
+++ b/iiif_prezi3/helpers/make_collection.py
@@ -11,7 +11,9 @@ class MakeCollection:
         and returns the newly created object. Accepts keyword arguments to
         customize the resulting instance.
         """
-        if 'items' not in kwargs or not kwargs['items']:
+        if 'items' not in kwargs:
+            child_collection = CollectionRef(**kwargs)
+        elif not kwargs['items']:
             kwargs.pop('items')
             child_collection = CollectionRef(**kwargs)
         else:

--- a/iiif_prezi3/helpers/make_manifest.py
+++ b/iiif_prezi3/helpers/make_manifest.py
@@ -11,9 +11,9 @@ class MakeManifest:
         calling Collection items and returns the newly created Manifest.
         Accepts keyword arguments to customize the resulting instance.
         """
+        kwargs.pop('items', None)
         manifest = ManifestRef(**kwargs)
         self.add_item(manifest)
-
         return manifest
 
 monkeypatch_schema(Collection, MakeManifest)

--- a/tests/test_make_collection.py
+++ b/tests/test_make_collection.py
@@ -10,7 +10,9 @@ class MakeCollectionTest(unittest.TestCase):
 
     def test_make_collection(self):
         child_collection = self.parent_collection.make_collection(
-            id='http://iiif.example.org/prezi/Manifest/0')
+            id='http://iiif.example.org/prezi/Manifest/0',
+            label="Example Collection"
+        )
         self.assertEqual(len(self.parent_collection.items), 1)
         self.assertEqual(child_collection.id,
                          'http://iiif.example.org/prezi/Manifest/0')

--- a/tests/test_make_collection.py
+++ b/tests/test_make_collection.py
@@ -16,3 +16,11 @@ class MakeCollectionTest(unittest.TestCase):
         self.assertEqual(len(self.parent_collection.items), 1)
         self.assertEqual(child_collection.id,
                          'http://iiif.example.org/prezi/Manifest/0')
+
+    def test_make_collection_ref(self):
+        child_collection = self.parent_collection.make_collection_ref(
+            id='http://iiif.example.org/prezi/Collection/0',
+            label="Example CollectionRef"
+        )
+        self.assertEqual(len(self.parent_collection.items), 1)
+        self.assertFalse(hasattr(child_collection, 'items'))


### PR DESCRIPTION
# What Does This Do?

This makes `MakeCollection` create a Collection when there are items or a CollectionRef when there are not. It also pops `items` on data for `MakeManifest` so that we don't accidentally end up with an embedded Manifest.  This is needed due to an issue with `Reference` and `extra.allow`.