### PR TITLE
Retry requests and allow custom session config

### DIFF
--- a/iiif_prezi3/config/http.py
+++ b/iiif_prezi3/config/http.py
@@ -1,0 +1,21 @@
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+# Configure retry logic (urllib3 - Retry)
+# See https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry
+_retries = Retry(
+    total=3,
+    backoff_factor=0.1,
+    allowed_methods={'GET'},
+    # also default value: adding for clarity
+    respect_retry_after_header=True,
+    #   413, 429, 503 by default
+    # status_forcelist=[502, 503, 504]
+
+)
+
+# Initialize the global DEFAULT_SESSION object which is loaded once
+DEFAULT_SESSION = Session()
+DEFAULT_SESSION.mount('https://', HTTPAdapter(max_retries=_retries))
+DEFAULT_SESSION.mount('http://', HTTPAdapter(max_retries=_retries))

--- a/iiif_prezi3/helpers/add_thumbnail.py
+++ b/iiif_prezi3/helpers/add_thumbnail.py
@@ -1,3 +1,6 @@
+from requests import Session
+
+from ..config.http import DEFAULT_SESSION
 from ..loader import monkeypatch_schema
 from ..skeleton import (AccompanyingCanvas, Annotation, AnnotationBody,
                         AnnotationCollection, AnnotationPage, Canvas,
@@ -63,7 +66,7 @@ class AddThumbnail:
         else:
             return f"{base_url}/full/max/0/default.jpg"
 
-    def create_thumbnail_from_iiif(self, url, preferred_width=500, **kwargs):
+    def create_thumbnail_from_iiif(self, url, preferred_width=500, iiif_session: Session = None, **kwargs):
         """Adds an image thumbnail to a manifest or canvas based on a IIIF service.
 
         If there is a sizes property, it returns the thumbnail that is closest to the preferred width but larger. If no
@@ -73,13 +76,16 @@ class AddThumbnail:
         Args:
             url (str): An HTTP URL which points at a IIIF Image response.
             preferred_width (int, optional): the preferred width of the thumbnail.
+            iiif_session (Session, optional): A requests Session object to use for the HTTP requests.
             **kwargs (): see AnnotationBody.
 
         Returns:
             new_thumbnail (AnnotationBody): The updated list of thumbnails, including the newly-created one.
         """
+        iiif_session = iiif_session or DEFAULT_SESSION
+
         image_response = AnnotationBody(id=url, type='Image')
-        image_info = image_response.set_hwd_from_iiif(url)
+        image_info = image_response.set_hwd_from_iiif(url, session=iiif_session)
         context = image_info.get('@context', '')
         aspect_ratio = image_info.get('width') / image_info.get('height')
         profile = self.__get_profile(image_info)

--- a/iiif_prezi3/helpers/create_canvas_from_iiif.py
+++ b/iiif_prezi3/helpers/create_canvas_from_iiif.py
@@ -1,4 +1,7 @@
 
+from requests import Session
+
+from ..config.http import DEFAULT_SESSION
 from ..loader import monkeypatch_schema
 from ..skeleton import (Annotation, AnnotationBody, AnnotationPage, Canvas,
                         Manifest, ServiceV2, ServiceV3)
@@ -7,7 +10,7 @@ from ..skeleton import (Annotation, AnnotationBody, AnnotationPage, Canvas,
 class CreateCanvasFromIIIF:
     # should probably be added to canvas helpers
 
-    def create_canvas_from_iiif(self, url, anno_id=None, anno_page_id=None, **kwargs):
+    def create_canvas_from_iiif(self, url, anno_id=None, anno_page_id=None, iiif_session: Session = None, **kwargs):
         """Create a canvas from a IIIF Image URL.
 
         Creates a canvas from a IIIF Image service passing any kwargs to the Canvas.
@@ -16,16 +19,18 @@ class CreateCanvasFromIIIF:
             url (str): An HTTP URL at which at a IIIF Image is available.
             anno_id (str): An HTTP URL for the annotation to which the image will be attached.
             anno_page_id (str): An HTTP URL for the annotation page to which the annotation will be attached.
+            iiif_session (Session): A requests Session object to use for the HTTP requests.
             **kwargs (): see Canvas
 
         Returns:
             canvas (Canvas): the Canvas created from the IIIF Image.
-
         """
+        iiif_session = iiif_session or DEFAULT_SESSION
+
         canvas = Canvas(**kwargs)
 
         body = AnnotationBody(id="http://example.com", type="Image")
-        infoJson = body.set_hwd_from_iiif(url)
+        infoJson = body.set_hwd_from_iiif(url, session=iiif_session)
 
         # Will need to handle IIIF 2...
         if 'type' not in infoJson:

--- a/iiif_prezi3/helpers/set_hwd_from_iiif.py
+++ b/iiif_prezi3/helpers/set_hwd_from_iiif.py
@@ -1,5 +1,7 @@
 import requests
+from requests import Session
 
+from ..config.http import DEFAULT_SESSION
 from ..loader import monkeypatch_schema
 from ..skeleton import AnnotationBody, Canvas, Resource
 
@@ -7,7 +9,7 @@ from ..skeleton import AnnotationBody, Canvas, Resource
 class SetHwdFromIIIF:
     # should probably be added to canvas helpers
 
-    def set_hwd_from_iiif(self, url):
+    def set_hwd_from_iiif(self, url, session: Session = None):
         """Set height and width on a Canvas object.
 
         Requests IIIF Image information remotely for an
@@ -16,13 +18,16 @@ class SetHwdFromIIIF:
 
         Args:
             url (str): An HTTP URL for the IIIF image endpoint.
+            session (Session): A requests Session object to use for the HTTP requests.
         """
+        session = session or DEFAULT_SESSION
+
         # resource url may or may not end with info.json;
         # add if not present
         if not url.endswith("info.json"):
             url = f"{url.rstrip('/')}/info.json"
 
-        response = requests.get(url)
+        response = session.get(url)
         # if response is not 200, raise exception
         if response.status_code != requests.codes.ok:
             response.raise_for_status()

--- a/tests/test_add_thumbnail.py
+++ b/tests/test_add_thumbnail.py
@@ -9,7 +9,7 @@ class AddThumbnailTests(unittest.TestCase):
     def setUp(self):
         self.manifest = Manifest(label={'en': ['Manifest label']})
 
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.Session.get')
     def test_create_thumbnail_from_iiif_v3_sizes_not_level_0(self, mockrequest_get):
         # This fixture is hosted by UCLA but used in Recipe 0234-provider
         image_id = 'https://iiif.library.ucla.edu/iiif/3/UCLA-Library-Logo-double-line-2'
@@ -20,66 +20,66 @@ class AddThumbnailTests(unittest.TestCase):
         mockrequest_get.return_value = mockresponse
         # set mock to return minimal image api response
         mockresponse.json.return_value = {
-          "@context": "http://iiif.io/api/image/3/context.json",
-          "id": "https://iiif.library.ucla.edu/iiif/3/UCLA-Library-Logo-double-line-2",
-          "type": "ImageService3",
-          "protocol": "http://iiif.io/api/image",
-          "profile": "level2",
-          "width": 1200,
-          "height": 502,
-          "maxArea": 602400,
-          "sizes": [
-            {
-              "width": 300,
-              "height": 126
-            },
-            {
-              "width": 600,
-              "height": 251
-            },
-            {
-              "width": 1200,
-              "height": 502
-            }
-          ],
-          "tiles": [
-            {
-              "width": 512,
-              "height": 502,
-              "scaleFactors": [
-                1,
-                2,
-                4
-              ]
-            }
-          ],
-          "extraQualities": [
-            "bitonal",
-            "color",
-            "gray"
-          ],
-          "extraFormats": [
-            "tif",
-            "gif"
-          ],
-          "extraFeatures": [
-            "baseUriRedirect",
-            "canonicalLinkHeader",
-            "cors",
-            "jsonldMediaType",
-            "mirroring",
-            "profileLinkHeader",
-            "regionByPct",
-            "regionByPx",
-            "regionSquare",
-            "rotationArbitrary",
-            "rotationBy90s",
-            "sizeByConfinedWh",
-            "sizeByH",
-            "sizeByPct",
-            "sizeByW",
-            "sizeByWh"
-          ]
+            "@context": "http://iiif.io/api/image/3/context.json",
+            "id": "https://iiif.library.ucla.edu/iiif/3/UCLA-Library-Logo-double-line-2",
+            "type": "ImageService3",
+            "protocol": "http://iiif.io/api/image",
+            "profile": "level2",
+            "width": 1200,
+            "height": 502,
+            "maxArea": 602400,
+            "sizes": [
+                {
+                  "width": 300,
+                  "height": 126
+                },
+                {
+                    "width": 600,
+                    "height": 251
+                },
+                {
+                    "width": 1200,
+                    "height": 502
+                }
+            ],
+            "tiles": [
+                {
+                    "width": 512,
+                    "height": 502,
+                    "scaleFactors": [
+                        1,
+                        2,
+                        4
+                    ]
+                }
+            ],
+            "extraQualities": [
+                "bitonal",
+                "color",
+                "gray"
+            ],
+            "extraFormats": [
+                "tif",
+                "gif"
+            ],
+            "extraFeatures": [
+                "baseUriRedirect",
+                "canonicalLinkHeader",
+                "cors",
+                "jsonldMediaType",
+                "mirroring",
+                "profileLinkHeader",
+                "regionByPct",
+                "regionByPx",
+                "regionSquare",
+                "rotationArbitrary",
+                "rotationBy90s",
+                "sizeByConfinedWh",
+                "sizeByH",
+                "sizeByPct",
+                "sizeByW",
+                "sizeByWh"
+            ]
         }
 
         thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
@@ -98,7 +98,7 @@ class AddThumbnailTests(unittest.TestCase):
         self.assertEqual(thumbnail.service[0].profile, "level2")
         self.assertEqual(thumbnail.service[0].type, "ImageService3")
 
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.Session.get')
     def test_create_thumbnail_from_iiif_v2_sizes_not_level_0(self, mockrequest_get):
         # This fixture is hosted by UCLA but used in Recipe 0234-provider
         image_id = 'https://iiif.library.ucla.edu/iiif/2/UCLA-Library-Logo-double-line-2'
@@ -187,7 +187,7 @@ class AddThumbnailTests(unittest.TestCase):
         self.assertEqual(thumbnail.service[0].profile, "level2")
         self.assertEqual(thumbnail.service[0].type, "ImageService3")
 
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.Session.get')
     def test_create_thumbnail_from_iiif_v3_sizes_level0(self, mockrequest_get):
         image_id = 'https://fixtures.iiif.io/other/level0/Glen/photos/gottingen'
         image_info_url = f'{image_id}/info.json'
@@ -248,59 +248,59 @@ class AddThumbnailTests(unittest.TestCase):
         self.assertEqual(thumbnail.service[0].profile, "level0")
         self.assertEqual(thumbnail.service[0].type, "ImageService3")
 
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.Session.get')
     def test_create_thumbnail_from_level_0_iiif_v2_sizes_level0(self, mockrequest_get):
         image_id = 'https://iiif-test.github.io/test2/images/IMG_8669'
         image_info_url = f'{image_id}/info.json'
         mockresponse = Mock(status_code=200)
         mockrequest_get.return_value = mockresponse
         mockresponse.json.return_value = {
-          "tiles": [
-            {
-              "scaleFactors": [
-                32,
-                16,
-                8,
-                4,
-                2,
-                1
-              ],
-              "width": 1024,
-              "height": 1024
-            }
-          ],
-          "protocol": "http://iiif.io/api/image",
-          "sizes": [
-            {
-              "width": 126,
-              "height": 95
-            },
-            {
-              "width": 252,
-              "height": 189
-            },
-            {
-              "width": 504,
-              "height": 378
-            },
-            {
-              "width": 1008,
-              "height": 756
-            },
-            {
-              "width": 2016,
-              "height": 1512
-            },
-            {
-              "width": 4032,
-              "height": 3024
-            }
-          ],
-          "profile": "http://iiif.io/api/image/2/level0.json",
-          "width": 4032,
-          "@id": "https://iiif-test.github.io/test2/images/IMG_8669",
-          "@context": "http://iiif.io/api/image/2/context.json",
-          "height": 3024
+            "tiles": [
+                {
+                    "scaleFactors": [
+                        32,
+                        16,
+                        8,
+                        4,
+                        2,
+                        1
+                    ],
+                    "width": 1024,
+                    "height": 1024
+                }
+            ],
+            "protocol": "http://iiif.io/api/image",
+            "sizes": [
+                {
+                    "width": 126,
+                    "height": 95
+                },
+                {
+                    "width": 252,
+                    "height": 189
+                },
+                {
+                    "width": 504,
+                    "height": 378
+                },
+                {
+                    "width": 1008,
+                    "height": 756
+                },
+                {
+                    "width": 2016,
+                    "height": 1512
+                },
+                {
+                    "width": 4032,
+                    "height": 3024
+                }
+            ],
+            "profile": "http://iiif.io/api/image/2/level0.json",
+            "width": 4032,
+            "@id": "https://iiif-test.github.io/test2/images/IMG_8669",
+            "@context": "http://iiif.io/api/image/2/context.json",
+            "height": 3024
         }
 
         thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
@@ -311,41 +311,41 @@ class AddThumbnailTests(unittest.TestCase):
             "https://iiif-test.github.io/test2/images/IMG_8669/full/504,/0/default.jpg"
         )
 
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.Session.get')
     def test_v3_with_no_sizes_prop(self, mockrequest_get):
         image_id = 'https://iiif.io/api/image/3.0/example/reference/4ce82cef49fb16798f4c2440307c3d6f-newspaper-p1'
         image_info_url = f'{image_id}/info.json'
         mockresponse = Mock(status_code=200)
         mockrequest_get.return_value = mockresponse
         mockresponse.json.return_value = {
-          "@context": "http://iiif.io/api/image/3/context.json",
-          "extraFormats": [
-            "jpg",
-            "png"
-          ],
-          "extraQualities": [
-            "default",
-            "color",
-            "gray"
-          ],
-          "height": 5000,
-          "id": "https://iiif.io/api/image/3.0/example/reference/4ce82cef49fb16798f4c2440307c3d6f-newspaper-p1",
-          "profile": "level1",
-          "protocol": "http://iiif.io/api/image",
-          "tiles": [
-            {
-              "height": 512,
-              "scaleFactors": [
-                1,
-                2,
-                4,
-                8
-              ],
-              "width": 512
-            }
-          ],
-          "type": "ImageService3",
-          "width": 3602
+            "@context": "http://iiif.io/api/image/3/context.json",
+            "extraFormats": [
+                "jpg",
+                "png"
+            ],
+            "extraQualities": [
+                "default",
+                "color",
+                "gray"
+            ],
+            "height": 5000,
+            "id": "https://iiif.io/api/image/3.0/example/reference/4ce82cef49fb16798f4c2440307c3d6f-newspaper-p1",
+            "profile": "level1",
+            "protocol": "http://iiif.io/api/image",
+            "tiles": [
+                {
+                  "height": 512,
+                  "scaleFactors": [
+                      1,
+                      2,
+                      4,
+                      8
+                  ],
+                    "width": 512
+                }
+            ],
+            "type": "ImageService3",
+            "width": 3602
         }
 
         thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url)[0]
@@ -356,7 +356,7 @@ class AddThumbnailTests(unittest.TestCase):
             f"{image_id}/full/500,694/0/default.jpg"
         )
 
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.Session.get')
     def test_create_thumbnail_from_iiif_v2_no_sizes(self, mockrequest_get):
         image_id = 'https://iiif.io/api/image/2.1/example/reference/918ecd18c2592080851777620de9bcb5-gottingen'
         image_info_url = f'{image_id}/info.json'
@@ -411,59 +411,59 @@ class AddThumbnailTests(unittest.TestCase):
         self.assertEqual(thumbnail.service[0].profile, "http://iiif.io/api/image/2/level1.json")
         self.assertEqual(thumbnail.service[0].type, "ImageService2")
 
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.Session.get')
     def test_create_thumbnail_from_iiif_giant_request_with_sizes(self, mockrequest_get):
         image_id = 'https://iiif-test.github.io/test2/images/IMG_8669'
         image_info_url = f'{image_id}/info.json'
         mockresponse = Mock(status_code=200)
         mockrequest_get.return_value = mockresponse
         mockresponse.json.return_value = {
-          "tiles": [
-            {
-              "scaleFactors": [
-                32,
-                16,
-                8,
-                4,
-                2,
-                1
-              ],
-              "width": 1024,
-              "height": 1024
-            }
-          ],
-          "protocol": "http://iiif.io/api/image",
-          "sizes": [
-            {
-              "width": 126,
-              "height": 95
-            },
-            {
-              "width": 252,
-              "height": 189
-            },
-            {
-              "width": 504,
-              "height": 378
-            },
-            {
-              "width": 1008,
-              "height": 756
-            },
-            {
-              "width": 2016,
-              "height": 1512
-            },
-            {
-              "width": 4032,
-              "height": 3024
-            }
-          ],
-          "profile": "http://iiif.io/api/image/2/level0.json",
-          "width": 4032,
-          "@id": "https://iiif-test.github.io/test2/images/IMG_8669",
-          "@context": "http://iiif.io/api/image/2/context.json",
-          "height": 3024
+            "tiles": [
+                {
+                    "scaleFactors": [
+                        32,
+                        16,
+                        8,
+                        4,
+                        2,
+                        1
+                    ],
+                    "width": 1024,
+                    "height": 1024
+                }
+            ],
+            "protocol": "http://iiif.io/api/image",
+            "sizes": [
+                {
+                    "width": 126,
+                    "height": 95
+                },
+                {
+                    "width": 252,
+                    "height": 189
+                },
+                {
+                    "width": 504,
+                    "height": 378
+                },
+                {
+                    "width": 1008,
+                    "height": 756
+                },
+                {
+                    "width": 2016,
+                    "height": 1512
+                },
+                {
+                    "width": 4032,
+                    "height": 3024
+                }
+            ],
+            "profile": "http://iiif.io/api/image/2/level0.json",
+            "width": 4032,
+            "@id": "https://iiif-test.github.io/test2/images/IMG_8669",
+            "@context": "http://iiif.io/api/image/2/context.json",
+            "height": 3024
         }
 
         giant_thumbnail = self.manifest.create_thumbnail_from_iiif(image_info_url, preferred_width=7000)[0]

--- a/tests/test_create_canvas_from_iiif.py
+++ b/tests/test_create_canvas_from_iiif.py
@@ -9,7 +9,7 @@ class CreateCanvasFromIIIFTests(unittest.TestCase):
     def setUp(self):
         self.manifest = Manifest(label={'en': ['Manifest label']})
 
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.Session.get')
     def test_create_canvas_from_iiif_v3(self, mockrequest_get):
         image_id = 'https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen'
         image_info_url = f'{image_id}/info.json'
@@ -65,7 +65,7 @@ class CreateCanvasFromIIIFTests(unittest.TestCase):
         self.assertEqual(service.profile, "level1")
         self.assertEqual(service.type, "ImageService3")
 
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.Session.get')
     def test_create_canvas_from_iiif_v2(self, mockrequest_get):
         image_id = 'https://iiif.io/api/image/2.1/example/reference/918ecd18c2592080851777620de9bcb5-gottingen'
         image_info_url = f'{image_id}/info.json'

--- a/tests/test_set_hwd_from_iiif.py
+++ b/tests/test_set_hwd_from_iiif.py
@@ -11,7 +11,7 @@ class SetHwdFromIIIFTests(unittest.TestCase):
     def setUp(self):
         self.canvas = Canvas(id='http://iiif.example.org/prezi/Canvas/0')
 
-    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.requests.get')
+    @patch('iiif_prezi3.helpers.set_hwd_from_iiif.Session.get')
     def test_set_hwd_from_iiif(self, mockrequest_get):
         image_id = 'http://iiif.example.org/images/1234abcd'
         image_info_url = f'{image_id}/info.json'


### PR DESCRIPTION
It would be nice if the helpers for add_thumbnail and create_canvas_from_iiif reused the connection, retried on failure and could be configured.

Here is an attempt at implementing this. Didn't know where to put a shared Session global.

Retry logic is copied from the docs of the session of requests (https://requests.readthedocs.io/en/latest/user/advanced/#session-objects and https://requests.readthedocs.io/en/latest/user/advanced/#example-automatic-retries). Haven't checked out if the values are sane, but changed allowed methods to GET.


The idea is that if you need another configuration for the webrequests, you can configure your own session.

Updated the mocks, so that the tox tests passed locally.