### PR TITLE
add type to make collection in test valid

### DIFF
--- a/tests/test_make_collection.py
+++ b/tests/test_make_collection.py
@@ -20,7 +20,8 @@ class MakeCollectionTest(unittest.TestCase):
     def test_make_collection_ref(self):
         child_collection = self.parent_collection.make_collection_ref(
             id='http://iiif.example.org/prezi/Collection/0',
-            label="Example CollectionRef"
+            label="Example CollectionRef",
+            type="Collection"
         )
         self.assertEqual(len(self.parent_collection.items), 1)
         self.assertFalse(hasattr(child_collection, 'items'))


### PR DESCRIPTION
I looked at examples for using `make_collection_ref` in the tests and ended up with a manifest not working or validating, since type is required. Thought it would make sense to add it to the test, so that the output of the test is a valid manifest.

The `type=Collection` could maybe be added by the helper method instead, since the function name itself implies that it creates a ref to a collection, but a working example currently could be useful for someone else trying out the library.