### PR TITLE
Can navdate work without touching skeleton?

### DIFF
--- a/iiif_prezi3/base.py
+++ b/iiif_prezi3/base.py
@@ -128,14 +128,14 @@ class Base(BaseModel):
             mode='json'  # v2 requires explicit mode
         )
 
-        # Adding this to ensure Recipe 0230 still works since Pydantic 2 date serialization is different
+        # Force use Z
         def fix_datetime_format(obj):
             if isinstance(obj, dict):
                 return {k: fix_datetime_format(v) for k, v in obj.items()}
             elif isinstance(obj, list):
                 return [fix_datetime_format(item) for item in obj]
-            elif isinstance(obj, str) and obj.endswith('Z'):
-                return obj[:-1] + '+00:00'
+            elif isinstance(obj, str) and obj.endswith('+00:00') and 'T' in obj:
+                return obj[:-6] + 'Z'
             return obj
 
         dict_out = fix_datetime_format(dict_out)


### PR DESCRIPTION
# What does this do?

This is the same as #296 but does not touch the skeleton.  For some reason, when I started this back in February or March, I was also regenerating skeleton.  I assume that's because there are some in schema that will cause other recipes to break and I was trying to handle it all at once.  If better, we can just merge this and close #296 